### PR TITLE
fix: Extract session_id from metadata to top-level parameter

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -790,12 +790,26 @@ class MemoryRelayClient {
       tier?: string;
     },
   ): Promise<Memory> {
-    return this.request<Memory>("POST", "/v1/memories", {
+    // Extract session_id from metadata if present and move to top-level
+    const { session_id, ...cleanMetadata } = metadata || {};
+    
+    const payload: any = {
       content,
-      metadata,
       agent_id: this.agentId,
       ...options,
-    });
+    };
+    
+    // Only include metadata if there's something left after extracting session_id
+    if (Object.keys(cleanMetadata).length > 0) {
+      payload.metadata = cleanMetadata;
+    }
+    
+    // Add session_id as top-level parameter if provided
+    if (session_id) {
+      payload.session_id = session_id;
+    }
+    
+    return this.request<Memory>("POST", "/v1/memories", payload);
   }
 
   async search(


### PR DESCRIPTION
## Summary

Fixes #24 - Extracts `session_id` from metadata to top-level parameter in `memory_store()` API requests.

## Problem

The `memory_store()` tool was passing `session_id` nested in the `metadata` object, preventing session-memory linking from working. The MemoryRelay API expects `session_id` as a top-level parameter.

### Before (broken):
```json
{
  "content": "Memory content",
  "agent_id": "agent-uuid",
  "metadata": {
    "session_id": "session-uuid",  // ❌ Wrong location
    "category": "test"
  }
}
```

### After (fixed):
```json
{
  "content": "Memory content",
  "agent_id": "agent-uuid",
  "session_id": "session-uuid",  // ✅ Top-level parameter
  "metadata": {
    "category": "test"
  }
}
```

## Changes

- Extract `session_id` from metadata before sending request
- Add `session_id` as top-level parameter in payload
- Keep remaining metadata in metadata object
- Backward compatible - works with or without `session_id`

## Implementation

The fix extracts `session_id` from the metadata object using destructuring:

```typescript
const { session_id, ...cleanMetadata } = metadata || {};
```

Then builds the payload conditionally:
1. Include clean metadata only if non-empty
2. Add `session_id` as top-level param if present

## Testing

Verified that backend correctly handles top-level `session_id` parameter:
- Created test session `0804c4cb...`
- Stored memory with `session_id` as top-level param
- Result: `memory_count: 1` ✅ and memory appears in `memories` array ✅

See memoryrelay/api#226 for backend verification details.

## Breaking Changes

None - this fix is backward compatible:
- If no `session_id` in metadata: works as before
- If `session_id` in metadata: extracted and passed correctly
- Other metadata fields preserved as-is

## Related Issues

- Closes #24
- Related: memoryrelay/api#226 (backend fix - resolved)
