### PR TITLE
chore: bump version to 0.15.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.3] - 2026-03-19
+
+### Fixed
+- **CRITICAL:** `memory_list` and `memory_forget` now display full UUIDs instead of truncated 8-char hex IDs, fixing 422 validation errors when using listed IDs with `memory_get`/`memory_forget` (#43)
+- **HIGH:** `subagent_ended` hook no longer unconditionally stores every completion event as a memory. Storage is now gated behind `autoCapture` config, respects the blocklist, and skips routine `ok`/`success` outcomes — only failures and unusual outcomes are persisted (#44)
+
 ## [0.15.2] - 2026-03-18
 
 ### Fixed

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 /**
  * OpenClaw Memory Plugin - MemoryRelay
- * Version: 0.15.2
+ * Version: 0.15.3
  *
  * Long-term memory with vector search using MemoryRelay API.
  * Provides auto-recall and auto-capture via lifecycle hooks.
@@ -711,7 +711,7 @@ class MemoryRelayClient {
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${this.apiKey}`,
-            "User-Agent": "openclaw-memory-memoryrelay/0.15.2",
+            "User-Agent": "openclaw-memory-memoryrelay/0.15.3",
           },
           body: body ? JSON.stringify(body) : undefined,
         },
@@ -4508,7 +4508,7 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
   });
 
   api.logger.info?.(
-    `memory-memoryrelay: plugin v0.15.2 loaded (${Object.values(TOOL_GROUPS).flat().length} tools, autoRecall: ${cfg?.autoRecall}, autoCapture: ${autoCaptureConfig.enabled ? autoCaptureConfig.tier : 'off'}, debug: ${debugEnabled})`,
+    `memory-memoryrelay: plugin v0.15.3 loaded (${Object.values(TOOL_GROUPS).flat().length} tools, autoRecall: ${cfg?.autoRecall}, autoCapture: ${autoCaptureConfig.enabled ? autoCaptureConfig.tier : 'off'}, debug: ${debugEnabled})`,
   );
 
   // ========================================================================
@@ -5604,7 +5604,7 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
     description: "Show how to update the MemoryRelay plugin to the latest version",
     requireAuth: true,
     handler: async (_ctx) => {
-      const currentVersion = "0.15.2";
+      const currentVersion = "0.15.3";
       const lines: string[] = [
         "MemoryRelay Plugin Update",
         "━".repeat(50),

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,8 +2,8 @@
   "id": "plugin-memoryrelay-ai",
   "kind": "memory",
   "name": "MemoryRelay AI",
-  "description": "MemoryRelay v0.15.2 - Long-term memory with 42 tools, 17 commands, V2 async, sessions, decisions, patterns & projects (api.memoryrelay.net)",
-  "version": "0.15.2",
+  "description": "MemoryRelay v0.15.3 - Long-term memory with 42 tools, 17 commands, V2 async, sessions, decisions, patterns & projects (api.memoryrelay.net)",
+  "version": "0.15.3",
   "uiHints": {
     "apiKey": {
       "label": "MemoryRelay API Key",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoryrelay/plugin-memoryrelay-ai",
-  "version": "0.15.2",
+  "version": "0.15.3",
   "description": "OpenClaw memory plugin for MemoryRelay API - 42 tools, 17 commands, V2 async, sessions, decisions, patterns, projects & semantic search",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
## Summary

- Bumps version from `0.15.2` → `0.15.3` across all files (package.json, openclaw.plugin.json, index.ts header, User-Agent, startup log, /memory-update command)
- Adds CHANGELOG entry for v0.15.3 covering fixes from #43 and #44

## Files changed

- `package.json` — version field
- `openclaw.plugin.json` — version + description
- `index.ts` — header comment, User-Agent string, startup log, /memory-update version
- `CHANGELOG.md` — new v0.15.3 section

## Test plan

- [x] All 124 tests pass
- [x] No stale `0.15.2` references remain (excluding CHANGELOG history)
- [x] Version consistent across all 4 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)