### PR TITLE
fix: stats() calls correct API endpoint (#47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.4] - 2026-03-21
+
+### Fixed
+- `stats()` method now calls correct API endpoint `/v1/agents/{agent_id}/stats` instead of non-existent `/v1/stats?agent_id=...` which returned 404 (#47)
+
 ## [0.15.3] - 2026-03-19
 
 ### Fixed

--- a/index.ts
+++ b/index.ts
@@ -1324,7 +1324,7 @@ class MemoryRelayClient {
   async stats(): Promise<Stats> {
     const response = await this.request<{ data: Stats }>(
       "GET",
-      `/v1/stats?agent_id=${encodeURIComponent(this.agentId)}`,
+      `/v1/agents/${encodeURIComponent(this.agentId)}/stats`,
     );
     return {
       total_memories: response.data?.total_memories ?? 0,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoryrelay/plugin-memoryrelay-ai",
-  "version": "0.15.3",
+  "version": "0.15.4",
   "description": "OpenClaw memory plugin for MemoryRelay API - 42 tools, 17 commands, V2 async, sessions, decisions, patterns, projects & semantic search",
   "type": "module",
   "main": "index.ts",


### PR DESCRIPTION
## Summary
- Fixed `stats()` method to call `/v1/agents/{agent_id}/stats` instead of non-existent `/v1/stats?agent_id=...` which returned 404
- Bumped version to 0.15.4
- Updated CHANGELOG

Closes #47

## Test plan
- [ ] Verify `memory_health` tool no longer shows 404 for stats
- [ ] Verify `/memory-status` command displays memory statistics
- [ ] Verify daily heartbeat stats retrieval works

🤖 Generated with [Claude Code](https://claude.com/claude-code)