### PR TITLE
fix: align plugin with API schemas and fix documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,6 @@ memory (9), entity (4), agent (3), session (4), decision (4), pattern (4), proje
 
 - Plugin ID is `plugin-memoryrelay-ai` (not `memory-memoryrelay`) — wrong ID causes "No install record" errors
 - `memory_batch_store` may return 500 on large batches — use individual `memory_store` as workaround
-- `memory_context` returns 405 on some API versions — use `memory_recall` instead
 - `memory_list` limit is capped at 100 to prevent 422 errors (v0.15.6 fix)
 - DebugLogger is duplicated: inlined in `index.ts` AND in `src/debug-logger.ts` — keep both in sync
 - `logFile` config option is deprecated and ignored since v0.8.4 (security compliance)

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Persistent memory, architectural decisions, reusable patterns, and project orchestration for AI agents.
 
 [![npm version](https://img.shields.io/npm/v/@memoryrelay/plugin-memoryrelay-ai.svg)](https://www.npmjs.com/package/@memoryrelay/plugin-memoryrelay-ai)
-[![OpenClaw Compatible](https://img.shields.io/badge/OpenClaw-2026.2.26+-blue.svg)](https://openclaw.ai)
+[![OpenClaw Compatible](https://img.shields.io/badge/OpenClaw-2026.2.0+-blue.svg)](https://openclaw.ai)
 
 ## Why MemoryRelay?
 
@@ -23,7 +23,7 @@ MemoryRelay is designed for engineering teams managing complex, long-running pro
 | Auto-capture with privacy tiers | Yes (off/conservative/smart/aggressive) | Basic | No |
 | V2 Async Storage | Yes | No | No |
 | Direct commands | 17 | ~5 | 0 |
-| Lifecycle hooks | 13 | 0 | 0 |
+| Lifecycle hooks | 14 | 0 | 0 |
 | Tools | 42 | ~10 | 0 |
 
 ## Quick Start
@@ -382,7 +382,6 @@ Then inspect with `/memory-logs` or `/memory-metrics` to identify slow or failin
 ### Known Limitations
 
 - `memory_batch_store`: May return 500 errors on large batches (use individual `memory_store` as workaround)
-- `memory_context`: Returns 405 Method Not Allowed on some API versions (use `memory_recall` instead)
 
 ## Development
 

--- a/index.ts
+++ b/index.ts
@@ -1625,7 +1625,7 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
   // Helper to check if a tool is enabled (by group)
   // ========================================================================
 
-  // Tool group mapping — matches MCP server's TOOL_GROUPS
+  // Plugin tool group mapping
   const TOOL_GROUPS: Record<string, string[]> = {
     memory: [
       "memory_store", "memory_recall", "memory_forget", "memory_list",
@@ -1701,7 +1701,7 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
             },
             dedup_threshold: {
               type: "number",
-              description: "Similarity threshold for deduplication (0-1). Default 0.9.",
+              description: "Similarity threshold for deduplication (0-1). Default 0.95.",
             },
             project: {
               type: "string",
@@ -2997,6 +2997,11 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
               description: "Tags for the new decision.",
               items: { type: "string" },
             },
+            metadata: {
+              type: "object",
+              description: "Optional key-value metadata to attach to the new decision.",
+              additionalProperties: { type: "string" },
+            },
           },
           required: ["id", "title", "rationale"],
         },
@@ -3008,6 +3013,7 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
             rationale: string;
             alternatives?: string;
             tags?: string[];
+            metadata?: Record<string, string>;
           },
         ) => {
           try {
@@ -3017,6 +3023,7 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
               args.rationale,
               args.alternatives,
               args.tags,
+              args.metadata,
             );
             return {
               content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
@@ -3843,6 +3850,10 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
             description: "Memory tier: hot, warm, or cold.",
             enum: ["hot", "warm", "cold"],
           },
+          webhook_url: {
+            type: "string",
+            description: "Optional webhook URL to notify when async storage completes.",
+          },
         },
         required: ["content"],
       },
@@ -3854,13 +3865,14 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
           project?: string;
           importance?: number;
           tier?: string;
+          webhook_url?: string;
         },
       ) => {
         try {
-          const { content, metadata, importance, tier } = args;
+          const { content, metadata, importance, tier, webhook_url } = args;
           let project = args.project;
           if (!project && defaultProject) project = defaultProject;
-          const result = await client.storeAsync(content, metadata, project, importance, tier);
+          const result = await client.storeAsync(content, metadata, project, importance, tier, webhook_url);
           return {
             content: [
               {
@@ -3962,6 +3974,14 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
             description: "Memory IDs to exclude from results.",
             items: { type: "string" },
           },
+          llm_api_url: {
+            type: "string",
+            description: "Optional custom LLM API URL for AI summarization.",
+          },
+          llm_model: {
+            type: "string",
+            description: "Optional LLM model name for AI summarization.",
+          },
         },
         required: ["query"],
       },
@@ -3974,6 +3994,8 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
           ai_enhanced?: boolean;
           search_mode?: "semantic" | "hybrid" | "keyword";
           exclude_memory_ids?: string[];
+          llm_api_url?: string;
+          llm_model?: string;
         },
       ) => {
         try {
@@ -3983,6 +4005,8 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
             aiEnhanced: args.ai_enhanced,
             searchMode: args.search_mode,
             excludeMemoryIds: args.exclude_memory_ids,
+            llmApiUrl: args.llm_api_url,
+            llmModel: args.llm_model,
           });
           return {
             content: [

--- a/skills/decision-tracking/SKILL.md
+++ b/skills/decision-tracking/SKILL.md
@@ -13,7 +13,7 @@ Decisions are **choices with rationale and alternatives considered**. Plain fact
 |------|-----------|---------|
 | `decision_record` | `decision_record(title, rationale, alternatives?, project?, tags?, status?)` | Record a new decision with reasoning |
 | `decision_list` | `decision_list(project?, status?, tags?, limit?)` | List decisions, optionally filtered |
-| `decision_supersede` | `decision_supersede(old_id, new_title, new_rationale, tags?)` | Replace an outdated decision |
+| `decision_supersede` | `decision_supersede(id, new_title, new_rationale, tags?)` | Replace an outdated decision |
 | `decision_check` | `decision_check(query, project?, limit?, threshold?)` | Semantic search for conflicting decisions |
 
 ## Workflow

--- a/skills/entity-and-context/SKILL.md
+++ b/skills/entity-and-context/SKILL.md
@@ -15,7 +15,7 @@ Entities turn flat memory storage into a connected knowledge graph. Create entit
 | `entity_link` | `entity_link(entity_id, memory_id, relationship?)` | Connect an entity to a memory |
 | `entity_list` | `entity_list(limit?, offset?)` | List entities with pagination |
 | `entity_graph` | `entity_graph(entity_id, depth?, max_neighbors?)` | Explore an entity's neighborhood |
-| `memory_context` | `memory_context(query, token_budget?)` | Enriched recall with entity connections (see `memory-workflow` skill) |
+| `memory_context` | `memory_context(query, max_tokens?)` | Enriched recall with entity connections (see `memory-workflow` skill) |
 
 ## Entity Types
 

--- a/skills/memory-workflow/SKILL.md
+++ b/skills/memory-workflow/SKILL.md
@@ -40,7 +40,7 @@ Call `session_end(session_id, summary)` with a meaningful summary. This becomes 
 
 ## Deduplication
 
-Always pass `deduplicate=true` on `memory_store` and `memory_batch_store`. The default threshold is 0.9 similarity. Skipping this clutters search results with near-duplicates.
+Always pass `deduplicate=true` on `memory_store` and `memory_batch_store`. The default threshold is 0.95 similarity. Skipping this clutters search results with near-duplicates.
 
 ## Metadata Best Practices
 


### PR DESCRIPTION
## Summary
- **Fix: `dedup_threshold` description** — `0.9`→`0.95` to match API default
- **Add: `llm_api_url` and `llm_model`** params to `context_build` tool
- **Add: `webhook_url`** param to `memory_store_async` tool
- **Add: `metadata`** param to `decision_supersede` tool
- **Fix: README** — hook count 13→14, remove stale memory_context 405 note, fix version badge to match peerDep
- **Fix: Skills** — `token_budget`→`max_tokens` in entity-and-context, `old_id`→`id` in decision-tracking, dedup threshold in memory-workflow
- **Fix: Comment** — remove false "matches MCP server" tool groups claim

## Test plan
- [ ] Verify `context_build` with `llm_api_url` and `llm_model` passes params to API
- [ ] Verify `memory_store_async` with `webhook_url` passes param to API
- [ ] Verify `decision_supersede` with `metadata` passes param to API
- [ ] Verify README renders correctly
- [ ] Test plugin loads without errors in OpenClaw

🤖 Generated with [Claude Code](https://claude.com/claude-code)