### PR TITLE
fix: memory status shows available when plugin is connected (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2026-03-29
+
+### Fixed
+- Register `memory.probe` gateway method so `openclaw status` shows "available" instead of "unavailable" when plugin-memoryrelay-ai holds the memory slot (#57)
+- User-Agent updated to v0.16.1
+
 ## [0.16.0] - 2026-03-28
 
 ### Added

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 /**
  * OpenClaw Memory Plugin - MemoryRelay
- * Version: 0.16.0
+ * Version: 0.16.1
  *
  * Long-term memory with vector search using MemoryRelay API.
  * Provides auto-recall and auto-capture via lifecycle hooks.
@@ -404,7 +404,7 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
   // ========================================================================
 
   api.logger.info?.(
-    `memory-memoryrelay: plugin v0.16.0 loaded (${Object.values(TOOL_GROUPS).flat().length} tools, autoRecall: ${pluginConfig.autoRecall}, autoCapture: ${autoCaptureConfig.enabled ? autoCaptureConfig.tier : "off"}, debug: ${debugEnabled})`,
+    `memory-memoryrelay: plugin v0.16.1 loaded (${Object.values(TOOL_GROUPS).flat().length} tools, autoRecall: ${pluginConfig.autoRecall}, autoCapture: ${autoCaptureConfig.enabled ? autoCaptureConfig.tier : "off"}, debug: ${debugEnabled})`,
   );
 
   // ========================================================================
@@ -439,8 +439,34 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
   }
 
   // ========================================================================
-  // Gateway Methods (memory.status, memoryrelay.*)
+  // Gateway Methods (memory.probe, memory.status, memoryrelay.*)
   // ========================================================================
+
+  // memory.probe — lightweight probe so `openclaw status` shows "available"
+  // instead of "unavailable". OpenClaw checks this to determine if the memory
+  // slot has a functioning provider.
+  api.registerGatewayMethod?.("memory.probe", async ({ respond }) => {
+    try {
+      const health = await client.health();
+      const healthStatus = String(health.status).toLowerCase();
+      const isConnected = VALID_HEALTH_STATUSES.includes(healthStatus);
+
+      respond(true, {
+        available: isConnected,
+        provider: "memoryrelay",
+        endpoint: apiUrl,
+        vector: { available: true, enabled: true },
+      });
+    } catch (_err) {
+      respond(true, {
+        available: false,
+        provider: "memoryrelay",
+        endpoint: apiUrl,
+        error: String(_err),
+        vector: { available: false, enabled: true },
+      });
+    }
+  });
 
   api.registerGatewayMethod?.("memory.status", async ({ respond }) => {
     try {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,8 +2,8 @@
   "id": "plugin-memoryrelay-ai",
   "kind": "memory",
   "name": "MemoryRelay AI",
-  "description": "MemoryRelay v0.16.0 - Long-term memory with pipeline architecture, 42 tools, 17 commands, V2 async, sessions, decisions, patterns & projects (api.memoryrelay.net)",
-  "version": "0.16.0",
+  "description": "MemoryRelay v0.16.1 - Long-term memory with pipeline architecture, 42 tools, 17 commands, V2 async, sessions, decisions, patterns & projects (api.memoryrelay.net)",
+  "version": "0.16.1",
   "uiHints": {
     "apiKey": {
       "label": "MemoryRelay API Key",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memoryrelay/plugin-memoryrelay-ai",
-  "version": "0.12.11",
+  "version": "0.16.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memoryrelay/plugin-memoryrelay-ai",
-      "version": "0.12.11",
+      "version": "0.16.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoryrelay/plugin-memoryrelay-ai",
-  "version": "0.16.0",
+  "version": "0.16.1",
   "description": "OpenClaw memory plugin for MemoryRelay API - 42 tools, 17 commands, V2 async, sessions, decisions, patterns, projects & semantic search",
   "type": "module",
   "main": "index.ts",

--- a/src/client/memoryrelay-client.ts
+++ b/src/client/memoryrelay-client.ts
@@ -153,7 +153,7 @@ export class MemoryRelayClient implements IMemoryRelayClient {
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${this.apiKey}`,
-            "User-Agent": "openclaw-memory-memoryrelay/0.16.0",
+            "User-Agent": "openclaw-memory-memoryrelay/0.16.1",
           },
           body: body ? JSON.stringify(body) : undefined,
         },


### PR DESCRIPTION
## Summary
- Registers `memory.probe` gateway method so OpenClaw's status renderer gets a valid memory response and shows "available" instead of "unavailable"
- When `openclaw status` probes the memory slot, the plugin now responds with availability, provider name, endpoint, and vector search status
- Bumps version to 0.16.1 (package.json, plugin manifest, User-Agent, index.ts header)

Fixes #57.

## Test plan
- [x] All 256 existing tests pass (`npm test`)
- [ ] Manual: run `openclaw status` with plugin-memoryrelay-ai installed — should show `Memory   enabled (plugin plugin-memoryrelay-ai)` without `· unavailable`
- [ ] Manual: disconnect API key and verify status shows `available: false` gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>