### PR TITLE
feat: add better-sqlite3 and schema module (v0.17.0 #63)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -225,6 +225,47 @@
           }
         }
       },
+      "localCache": {
+        "type": "object",
+        "description": "Local SQLite cache for fast, offline-capable memory access",
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "Enable local SQLite cache layer"
+          },
+          "syncIntervalMinutes": {
+            "type": "number",
+            "default": 5,
+            "minimum": 1,
+            "maximum": 60,
+            "description": "How often to sync with the API (minutes)"
+          },
+          "maxLocalMemories": {
+            "type": "number",
+            "default": 1000,
+            "minimum": 100,
+            "maximum": 10000,
+            "description": "Maximum number of memories to keep locally"
+          },
+          "vectorSearch": {
+            "type": "object",
+            "properties": {
+              "enabled": { "type": "boolean", "default": true },
+              "provider": { "type": "string", "default": "sqlite-vec" }
+            }
+          },
+          "ttl": {
+            "type": "object",
+            "description": "Time-to-live per tier (hours)",
+            "properties": {
+              "hot": { "type": "number", "default": 72 },
+              "warm": { "type": "number", "default": 168 },
+              "cold": { "type": "number", "default": 720 }
+            }
+          }
+        }
+      },
       "ranking": {
         "type": "object",
         "properties": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,11 @@
       "name": "@memoryrelay/plugin-memoryrelay-ai",
       "version": "0.16.3",
       "license": "MIT",
+      "dependencies": {
+        "better-sqlite3": "^12.8.0"
+      },
       "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^25.3.5",
         "@vitest/coverage-v8": "^1.2.0",
         "typescript": "^5.9.3",
@@ -3837,6 +3841,16 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/better-sqlite3": {
+      "version": "7.6.13",
+      "resolved": "https://registry.npmjs.org/@types/better-sqlite3/-/better-sqlite3-7.6.13.tgz",
+      "integrity": "sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "license": "MIT",
@@ -4378,8 +4392,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/basic-ftp": {
       "version": "5.2.0",
@@ -4394,12 +4407,60 @@
       "license": "Apache-2.0",
       "peer": true
     },
+    "node_modules/better-sqlite3": {
+      "version": "12.8.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.8.0.tgz",
+      "integrity": "sha512-RxD2Vd96sQDjQr20kdP+F+dK/1OUNiVOl200vKBZY8u0vTwysfolF6Hq+3ZK2+h8My9YvZhHsF+RSGZW2VYrPQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      },
+      "engines": {
+        "node": "20.x || 22.x || 23.x || 24.x || 25.x"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/body-parser": {
@@ -4449,6 +4510,30 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-crc32": {
@@ -5002,6 +5087,21 @@
         }
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "dev": true,
@@ -5016,7 +5116,6 @@
     "node_modules/deep-extend": {
       "version": "0.6.0",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -5059,7 +5158,6 @@
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5197,7 +5295,6 @@
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -5832,6 +5929,15 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
@@ -6009,6 +6115,12 @@
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/filename-reserved-regex": {
       "version": "3.0.0",
       "license": "MIT",
@@ -6159,6 +6271,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "11.3.4",
@@ -6478,6 +6596,12 @@
         "node": ">= 14"
       }
     },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "13.0.6",
       "license": "BlueOak-1.0.0",
@@ -6757,8 +6881,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "7.0.5",
@@ -6788,8 +6911,7 @@
     },
     "node_modules/ini": {
       "version": "1.3.8",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -7510,6 +7632,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "10.2.4",
       "license": "BlueOak-1.0.0",
@@ -7527,7 +7661,6 @@
     "node_modules/minimist": {
       "version": "1.2.8",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7562,6 +7695,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.8.1",
@@ -7640,6 +7779,12 @@
         "node": "^18 || >=20"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "license": "MIT",
@@ -7654,6 +7799,18 @@
       "peer": true,
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-addon-api": {
@@ -8557,6 +8714,33 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pretty-bytes": {
       "version": "6.1.1",
       "license": "MIT",
@@ -8721,7 +8905,6 @@
     "node_modules/pump": {
       "version": "3.0.4",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -8797,7 +8980,6 @@
     "node_modules/rc": {
       "version": "1.2.8",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
-      "peer": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -9390,8 +9572,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
@@ -10053,6 +10234,51 @@
       "license": "ISC",
       "peer": true
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/simple-git": {
       "version": "3.32.3",
       "license": "MIT",
@@ -10325,15 +10551,13 @@
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -10464,7 +10688,6 @@
     "node_modules/strip-json-comments": {
       "version": "2.0.1",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10529,6 +10752,54 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-fs/node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/test-exclude": {
@@ -10703,6 +10974,18 @@
         "node": ">=0.6.x"
       }
     },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/type-detect": {
       "version": "4.1.0",
       "dev": true,
@@ -10809,8 +11092,7 @@
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "openclaw": ">=2026.2.0"
   },
   "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
     "@types/node": "^25.3.5",
     "@vitest/coverage-v8": "^1.2.0",
     "typescript": "^5.9.3",
@@ -53,5 +54,8 @@
   ],
   "engines": {
     "node": ">=20.0.0"
+  },
+  "dependencies": {
+    "better-sqlite3": "^12.8.0"
   }
 }

--- a/src/cache/schema.ts
+++ b/src/cache/schema.ts
@@ -1,0 +1,126 @@
+import type Database from "better-sqlite3";
+
+export const SCHEMA_VERSION = 1;
+
+export const CREATE_MEMORIES_TABLE = `CREATE TABLE IF NOT EXISTS memories (
+  id            TEXT PRIMARY KEY,
+  remote_id     TEXT UNIQUE,
+  content       TEXT NOT NULL,
+  agent_id      TEXT NOT NULL,
+  user_id       TEXT DEFAULT '',
+  metadata      TEXT DEFAULT '{}',
+  entities      TEXT DEFAULT '[]',
+  importance    REAL DEFAULT 0.5,
+  tier          TEXT DEFAULT 'warm'
+                  CHECK(tier IN ('hot', 'warm', 'cold')),
+  scope         TEXT DEFAULT 'long-term'
+                  CHECK(scope IN ('session', 'long-term')),
+  session_id    TEXT,
+  namespace     TEXT DEFAULT 'default',
+  created_at    TEXT NOT NULL,
+  updated_at    TEXT NOT NULL,
+  synced_at     TEXT,
+  expires_at    TEXT,
+  embedding     BLOB
+)`;
+
+export const CREATE_MEMORIES_FTS = `CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+  content,
+  metadata,
+  content=memories,
+  content_rowid=rowid
+)`;
+
+export const CREATE_FTS_TRIGGER_INSERT = `CREATE TRIGGER IF NOT EXISTS memories_ai AFTER INSERT ON memories
+  BEGIN INSERT INTO memories_fts(rowid, content, metadata) VALUES (new.rowid, new.content, new.metadata); END`;
+
+export const CREATE_FTS_TRIGGER_DELETE = `CREATE TRIGGER IF NOT EXISTS memories_ad AFTER DELETE ON memories
+  BEGIN INSERT INTO memories_fts(memories_fts, rowid, content, metadata) VALUES ('delete', old.rowid, old.content, old.metadata); END`;
+
+export const CREATE_FTS_TRIGGER_UPDATE = `CREATE TRIGGER IF NOT EXISTS memories_au AFTER UPDATE ON memories
+  BEGIN INSERT INTO memories_fts(memories_fts, rowid, content, metadata) VALUES ('delete', old.rowid, old.content, old.metadata);
+        INSERT INTO memories_fts(rowid, content, metadata) VALUES (new.rowid, new.content, new.metadata); END`;
+
+export const CREATE_BUFFER_TABLE = `CREATE TABLE IF NOT EXISTS session_buffer (
+  id          INTEGER PRIMARY KEY AUTOINCREMENT,
+  content     TEXT NOT NULL,
+  metadata    TEXT DEFAULT '{}',
+  scope       TEXT DEFAULT 'long-term',
+  session_id  TEXT,
+  namespace   TEXT DEFAULT 'default',
+  created_at  TEXT NOT NULL,
+  flushed     INTEGER DEFAULT 0
+)`;
+
+export const CREATE_SYNC_STATE_TABLE = `CREATE TABLE IF NOT EXISTS sync_state (
+  key         TEXT PRIMARY KEY,
+  value       TEXT NOT NULL,
+  updated_at  TEXT NOT NULL
+)`;
+
+export const CREATE_CACHE_META_TABLE = `CREATE TABLE IF NOT EXISTS cache_meta (
+  key         TEXT PRIMARY KEY,
+  value       TEXT NOT NULL
+)`;
+
+export const CREATE_INDEXES = [
+  "CREATE INDEX IF NOT EXISTS idx_memories_agent     ON memories(agent_id)",
+  "CREATE INDEX IF NOT EXISTS idx_memories_tier      ON memories(tier)",
+  "CREATE INDEX IF NOT EXISTS idx_memories_scope     ON memories(scope)",
+  "CREATE INDEX IF NOT EXISTS idx_memories_session   ON memories(session_id)",
+  "CREATE INDEX IF NOT EXISTS idx_memories_namespace  ON memories(namespace)",
+  "CREATE INDEX IF NOT EXISTS idx_memories_expires   ON memories(expires_at)",
+  "CREATE INDEX IF NOT EXISTS idx_memories_synced    ON memories(synced_at)",
+  "CREATE INDEX IF NOT EXISTS idx_memories_updated   ON memories(updated_at DESC)",
+  "CREATE INDEX IF NOT EXISTS idx_buffer_flushed     ON session_buffer(flushed, created_at)",
+];
+
+/**
+ * Run a SQL statement on the database.
+ * Wrapper around Database.exec to keep schema module self-contained.
+ */
+function run(db: Database.Database, sql: string): void {
+  db.prepare(sql).run();
+}
+
+function runDDL(db: Database.Database, sql: string): void {
+  // For DDL statements (CREATE TABLE, CREATE INDEX, CREATE TRIGGER, CREATE VIRTUAL TABLE)
+  // we need to use the exec method on the database instance
+  const fn = (db as unknown as { exec: (sql: string) => void }).exec.bind(db);
+  fn(sql);
+}
+
+export function createSchema(db: Database.Database): void {
+  runDDL(db, CREATE_MEMORIES_TABLE);
+  runDDL(db, CREATE_MEMORIES_FTS);
+  runDDL(db, CREATE_FTS_TRIGGER_INSERT);
+  runDDL(db, CREATE_FTS_TRIGGER_DELETE);
+  runDDL(db, CREATE_FTS_TRIGGER_UPDATE);
+  runDDL(db, CREATE_BUFFER_TABLE);
+  runDDL(db, CREATE_SYNC_STATE_TABLE);
+  runDDL(db, CREATE_CACHE_META_TABLE);
+  for (const idx of CREATE_INDEXES) {
+    runDDL(db, idx);
+  }
+  db.prepare("INSERT OR REPLACE INTO cache_meta (key, value) VALUES ('schema_version', ?)").run(
+    String(SCHEMA_VERSION),
+  );
+}
+
+export function getSchemaVersion(db: Database.Database): number {
+  const row = db.prepare("SELECT value FROM cache_meta WHERE key = 'schema_version'").get() as
+    | { value: string }
+    | undefined;
+  return row ? parseInt(row.value, 10) : 0;
+}
+
+export function migrateIfNeeded(db: Database.Database): void {
+  // Ensure cache_meta exists so we can read the version
+  runDDL(db, CREATE_CACHE_META_TABLE);
+  const version = getSchemaVersion(db);
+
+  if (version < 1) {
+    createSchema(db);
+  }
+  // Future: if (version < 2) { runMigrationV2(db); }
+}

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -1,0 +1,52 @@
+export interface LocalCacheConfig {
+  enabled: boolean;
+  dbPath: string;
+  syncIntervalMinutes: number;
+  maxLocalMemories: number;
+  vectorSearch: { enabled: boolean; provider: string };
+  ttl: { hot: number; warm: number; cold: number };
+}
+
+export interface BufferEntry {
+  id: number;
+  content: string;
+  metadata: Record<string, string>;
+  scope: "session" | "long-term";
+  session_id?: string;
+  namespace: string;
+  created_at: string;
+  flushed: boolean;
+}
+
+export interface SyncState {
+  lastPull: string | null;
+  lastPush: string | null;
+  cursor: string | null;
+}
+
+export interface CacheStats {
+  totalMemories: number;
+  bufferDepth: number;
+  lastSync: string | null;
+  dbSizeBytes: number;
+}
+
+export interface LocalMemory {
+  id: string;
+  remote_id: string | null;
+  content: string;
+  agent_id: string;
+  user_id: string;
+  metadata: Record<string, unknown>;
+  entities: unknown[];
+  importance: number;
+  tier: "hot" | "warm" | "cold";
+  scope: "session" | "long-term";
+  session_id: string | null;
+  namespace: string;
+  created_at: string;
+  updated_at: string;
+  synced_at: string | null;
+  expires_at: string | null;
+  embedding: Buffer | null;
+}

--- a/tests/cache/schema.test.ts
+++ b/tests/cache/schema.test.ts
@@ -1,0 +1,233 @@
+import { describe, test, expect, beforeEach, afterEach } from "vitest";
+import Database from "better-sqlite3";
+import {
+  SCHEMA_VERSION,
+  createSchema,
+  migrateIfNeeded,
+  getSchemaVersion,
+  CREATE_MEMORIES_TABLE,
+  CREATE_MEMORIES_FTS,
+  CREATE_BUFFER_TABLE,
+  CREATE_SYNC_STATE_TABLE,
+  CREATE_CACHE_META_TABLE,
+} from "../../src/cache/schema";
+
+describe("cache/schema", () => {
+  let db: Database.Database;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  describe("createSchema()", () => {
+    test("creates all tables on fresh database", () => {
+      createSchema(db);
+
+      const tables = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        .all() as { name: string }[];
+      const tableNames = tables.map((t) => t.name);
+
+      expect(tableNames).toContain("memories");
+      expect(tableNames).toContain("session_buffer");
+      expect(tableNames).toContain("sync_state");
+      expect(tableNames).toContain("cache_meta");
+    });
+
+    test("creates FTS5 virtual table", () => {
+      createSchema(db);
+
+      const tables = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='memories_fts'")
+        .all();
+      expect(tables).toHaveLength(1);
+    });
+
+    test("creates FTS triggers", () => {
+      createSchema(db);
+
+      const triggers = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='trigger' ORDER BY name")
+        .all() as { name: string }[];
+      const triggerNames = triggers.map((t) => t.name);
+
+      expect(triggerNames).toContain("memories_ai");
+      expect(triggerNames).toContain("memories_ad");
+      expect(triggerNames).toContain("memories_au");
+    });
+
+    test("creates all indexes", () => {
+      createSchema(db);
+
+      const indexes = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='index' AND name LIKE 'idx_%' ORDER BY name")
+        .all() as { name: string }[];
+      const indexNames = indexes.map((i) => i.name);
+
+      expect(indexNames).toContain("idx_memories_agent");
+      expect(indexNames).toContain("idx_memories_tier");
+      expect(indexNames).toContain("idx_memories_scope");
+      expect(indexNames).toContain("idx_memories_session");
+      expect(indexNames).toContain("idx_memories_namespace");
+      expect(indexNames).toContain("idx_memories_expires");
+      expect(indexNames).toContain("idx_memories_synced");
+      expect(indexNames).toContain("idx_memories_updated");
+      expect(indexNames).toContain("idx_buffer_flushed");
+    });
+
+    test("stores schema version in cache_meta", () => {
+      createSchema(db);
+
+      const row = db
+        .prepare("SELECT value FROM cache_meta WHERE key = 'schema_version'")
+        .get() as { value: string };
+
+      expect(row).toBeDefined();
+      expect(parseInt(row.value, 10)).toBe(SCHEMA_VERSION);
+    });
+
+    test("is idempotent — running twice does not error", () => {
+      createSchema(db);
+      expect(() => createSchema(db)).not.toThrow();
+
+      // Version should still be correct
+      expect(getSchemaVersion(db)).toBe(SCHEMA_VERSION);
+    });
+  });
+
+  describe("getSchemaVersion()", () => {
+    test("returns 0 on empty database with only cache_meta table", () => {
+      db.prepare("CREATE TABLE cache_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)").run();
+      expect(getSchemaVersion(db)).toBe(0);
+    });
+
+    test("returns correct version after createSchema()", () => {
+      createSchema(db);
+      expect(getSchemaVersion(db)).toBe(SCHEMA_VERSION);
+    });
+  });
+
+  describe("migrateIfNeeded()", () => {
+    test("creates schema on fresh database", () => {
+      migrateIfNeeded(db);
+
+      const tables = db
+        .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+        .all() as { name: string }[];
+      const tableNames = tables.map((t) => t.name);
+
+      expect(tableNames).toContain("memories");
+      expect(tableNames).toContain("session_buffer");
+      expect(getSchemaVersion(db)).toBe(SCHEMA_VERSION);
+    });
+
+    test("is idempotent — running multiple times is safe", () => {
+      migrateIfNeeded(db);
+      migrateIfNeeded(db);
+      migrateIfNeeded(db);
+
+      expect(getSchemaVersion(db)).toBe(SCHEMA_VERSION);
+
+      // Verify tables still intact
+      const count = db.prepare("SELECT COUNT(*) as c FROM sqlite_master WHERE type='table'").get() as { c: number };
+      expect(count.c).toBeGreaterThan(0);
+    });
+
+    test("skips creation when schema is already current", () => {
+      createSchema(db);
+
+      // Insert a test row to verify data is preserved
+      const now = new Date().toISOString();
+      db.prepare(
+        "INSERT INTO memories (id, content, agent_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+      ).run("test-1", "hello", "agent-1", now, now);
+
+      migrateIfNeeded(db);
+
+      // Data should still be there
+      const row = db.prepare("SELECT content FROM memories WHERE id = 'test-1'").get() as { content: string };
+      expect(row.content).toBe("hello");
+    });
+  });
+
+  describe("FTS5 integration", () => {
+    test("FTS index is populated via trigger on INSERT", () => {
+      createSchema(db);
+
+      const now = new Date().toISOString();
+      db.prepare(
+        "INSERT INTO memories (id, content, agent_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+      ).run("m1", "the quick brown fox", "agent-1", now, now);
+
+      const results = db
+        .prepare("SELECT * FROM memories_fts WHERE memories_fts MATCH 'quick'")
+        .all();
+      expect(results).toHaveLength(1);
+    });
+
+    test("FTS index is updated via trigger on UPDATE", () => {
+      createSchema(db);
+
+      const now = new Date().toISOString();
+      db.prepare(
+        "INSERT INTO memories (id, content, agent_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+      ).run("m1", "original content", "agent-1", now, now);
+
+      db.prepare("UPDATE memories SET content = ? WHERE id = ?").run("updated content", "m1");
+
+      const oldResults = db
+        .prepare("SELECT * FROM memories_fts WHERE memories_fts MATCH 'original'")
+        .all();
+      expect(oldResults).toHaveLength(0);
+
+      const newResults = db
+        .prepare("SELECT * FROM memories_fts WHERE memories_fts MATCH 'updated'")
+        .all();
+      expect(newResults).toHaveLength(1);
+    });
+
+    test("FTS index is cleaned via trigger on DELETE", () => {
+      createSchema(db);
+
+      const now = new Date().toISOString();
+      db.prepare(
+        "INSERT INTO memories (id, content, agent_id, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
+      ).run("m1", "deletable content", "agent-1", now, now);
+
+      db.prepare("DELETE FROM memories WHERE id = ?").run("m1");
+
+      const results = db
+        .prepare("SELECT * FROM memories_fts WHERE memories_fts MATCH 'deletable'")
+        .all();
+      expect(results).toHaveLength(0);
+    });
+  });
+
+  describe("table constraints", () => {
+    test("memories tier CHECK constraint rejects invalid values", () => {
+      createSchema(db);
+
+      const now = new Date().toISOString();
+      expect(() =>
+        db.prepare(
+          "INSERT INTO memories (id, content, agent_id, tier, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+        ).run("m1", "content", "agent-1", "invalid", now, now),
+      ).toThrow();
+    });
+
+    test("memories scope CHECK constraint rejects invalid values", () => {
+      createSchema(db);
+
+      const now = new Date().toISOString();
+      expect(() =>
+        db.prepare(
+          "INSERT INTO memories (id, content, agent_id, scope, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)",
+        ).run("m1", "content", "agent-1", "invalid", now, now),
+      ).toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `better-sqlite3` + `@types/better-sqlite3` dependencies
- Creates `src/cache/types.ts` with `LocalCacheConfig`, `BufferEntry`, `SyncState`, `CacheStats`, `LocalMemory` types
- Creates `src/cache/schema.ts` with SQL constants (memories table, FTS5 virtual table, triggers, session_buffer, sync_state, cache_meta), `createSchema()`, `migrateIfNeeded()`, `getSchemaVersion()`
- Updates `openclaw.plugin.json` with `localCache` config schema section
- Adds 16 schema tests using `:memory:` SQLite (FTS5 integration, triggers, constraints, idempotency)
- All 272 tests pass (243 existing + 16 new + 13 pre-existing on branch)

## Test plan
- [x] `npm install` succeeds with better-sqlite3
- [x] `createSchema()` creates all tables, indexes, FTS5, triggers
- [x] `migrateIfNeeded()` is safe to call multiple times
- [x] FTS5 triggers work on INSERT, UPDATE, DELETE
- [x] CHECK constraints reject invalid tier/scope values
- [x] All 272 tests pass
- [x] No TypeScript errors in new files

Part of Epic #62, closes #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)