### PR TITLE
feat: buffer-first capture pipeline (v0.17.0 #67)

### DIFF
--- a/src/pipelines/capture/store.ts
+++ b/src/pipelines/capture/store.ts
@@ -20,14 +20,38 @@ export const captureStore: CaptureStage = {
       }
     }
 
+    let buffered = false;
+
     for (const msg of toStore) {
       const scope = resolveScope(msg.content);
-      const opts: Record<string, unknown> = { scope };
+      const metadata: Record<string, unknown> = { source: "auto-capture", scope };
       if (scope === "session" && sessionId) {
-        opts.session_id = sessionId;
+        metadata.session_id = sessionId;
       }
-      await ctx.client.store(msg.content, { source: "auto-capture", scope }, opts);
+      metadata.namespace = ctx.requestCtx.namespace;
+
+      if (ctx.localCache) {
+        try {
+          ctx.localCache.bufferWrite(msg.content, metadata);
+          buffered = true;
+        } catch {
+          // Buffer write failed — fall back to direct API call
+          const opts: Record<string, unknown> = { scope };
+          if (scope === "session" && sessionId) {
+            opts.session_id = sessionId;
+          }
+          await ctx.client.store(msg.content, { source: "auto-capture", scope }, opts);
+        }
+      } else {
+        // No local cache — direct API call (existing behavior)
+        const opts: Record<string, unknown> = { scope };
+        if (scope === "session" && sessionId) {
+          opts.session_id = sessionId;
+        }
+        await ctx.client.store(msg.content, { source: "auto-capture", scope }, opts);
+      }
     }
-    return { action: "continue", data: input };
+
+    return { action: "continue", data: input, buffered };
   },
 };

--- a/src/pipelines/types.ts
+++ b/src/pipelines/types.ts
@@ -115,11 +115,17 @@ export interface SessionResolverLike {
   resolve(requestCtx: RequestContext): Promise<{ sessionId: string; externalId: string }>;
 }
 
+export interface LocalCacheLike {
+  bufferWrite(content: string, metadata: Record<string, unknown>): string;
+  bufferDepth(): number;
+}
+
 export interface PipelineContext {
   readonly requestCtx: RequestContext;
   readonly config: PluginConfig;
   readonly client: MemoryRelayClient;
   readonly sessionResolver?: SessionResolverLike;
+  readonly localCache?: LocalCacheLike;
 }
 
 export interface RecallInput {
@@ -147,7 +153,7 @@ export interface CaptureInput {
 }
 
 export type CaptureResult =
-  | { action: "continue"; data: CaptureInput }
+  | { action: "continue"; data: CaptureInput; buffered?: boolean }
   | { action: "skip" };
 
 export interface CaptureStage {

--- a/tests/integration/capture-pipeline.test.ts
+++ b/tests/integration/capture-pipeline.test.ts
@@ -2,8 +2,9 @@
 import { describe, test, expect, vi } from "vitest";
 import { runPipeline } from "../../src/pipelines/runner.js";
 import { capturePipeline } from "../../src/pipelines/capture/index.js";
+import { captureStore } from "../../src/pipelines/capture/store.js";
 import { buildRequestContext } from "../../src/context/request-context.js";
-import type { PipelineContext, CaptureInput, MemoryRelayClient } from "../../src/pipelines/types.js";
+import type { PipelineContext, CaptureInput, MemoryRelayClient, LocalCacheLike } from "../../src/pipelines/types.js";
 
 function mockClient(): MemoryRelayClient {
   return {
@@ -16,6 +17,45 @@ function mockClient(): MemoryRelayClient {
     list: vi.fn(), getOrCreateSession: vi.fn(), endSession: vi.fn(),
   };
 }
+
+function mockLocalCache(): LocalCacheLike & { _buffer: Array<{ content: string; metadata: Record<string, unknown> }> } {
+  const cache = {
+    _buffer: [] as Array<{ content: string; metadata: Record<string, unknown> }>,
+    bufferWrite: vi.fn((content: string, metadata: Record<string, unknown>) => {
+      cache._buffer.push({ content, metadata });
+      return String(cache._buffer.length);
+    }),
+    bufferDepth: vi.fn(() => cache._buffer.length),
+  };
+  return cache;
+}
+
+function buildCtx(overrides: {
+  client?: MemoryRelayClient;
+  localCache?: LocalCacheLike;
+  sessionKey?: string;
+}): { pipelineCtx: PipelineContext; client: MemoryRelayClient } {
+  const client = overrides.client ?? mockClient();
+  const config = { autoCapture: { enabled: true, tier: "smart", maxMessageLength: 2000 }, agentId: "test" };
+  const requestCtx = buildRequestContext(
+    { ctx: { sessionKey: overrides.sessionKey ?? "agent:main:abc" }, prompt: "Test prompt" },
+    config as any,
+  );
+  const pipelineCtx: PipelineContext = {
+    requestCtx,
+    config: config as any,
+    client,
+    localCache: overrides.localCache,
+  };
+  return { pipelineCtx, client };
+}
+
+const valuableMessages: CaptureInput = {
+  messages: [
+    { role: "user", content: "I always prefer PostgreSQL for production databases" },
+    { role: "user", content: "Our deployment pipeline uses Docker Compose with health checks" },
+  ],
+};
 
 describe("capture pipeline end-to-end", () => {
   test("filters noise and stores valuable content", async () => {
@@ -95,5 +135,105 @@ describe("capture pipeline end-to-end", () => {
 
     expect(result).toBeNull();
     expect(client.store).not.toHaveBeenCalled();
+  });
+});
+
+describe("buffer-first capture", () => {
+  test("writes to local buffer instead of API when cache available", async () => {
+    const localCache = mockLocalCache();
+    const { pipelineCtx, client } = buildCtx({ localCache });
+
+    await runPipeline(capturePipeline, valuableMessages, pipelineCtx);
+
+    expect(localCache.bufferWrite).toHaveBeenCalled();
+    expect(client.store).not.toHaveBeenCalled();
+  });
+
+  test("returns immediately without API call", async () => {
+    const localCache = mockLocalCache();
+    const { pipelineCtx, client } = buildCtx({ localCache });
+
+    const start = performance.now();
+    await runPipeline(capturePipeline, valuableMessages, pipelineCtx);
+    const elapsed = performance.now() - start;
+
+    expect(client.store).not.toHaveBeenCalled();
+    // Buffer writes are synchronous SQLite — should complete well under 50ms in test
+    expect(elapsed).toBeLessThan(50);
+  });
+
+  test("bufferDepth increases after capture", async () => {
+    const localCache = mockLocalCache();
+    const { pipelineCtx } = buildCtx({ localCache });
+
+    expect(localCache.bufferDepth()).toBe(0);
+    await runPipeline(capturePipeline, valuableMessages, pipelineCtx);
+    expect(localCache.bufferDepth()).toBeGreaterThan(0);
+  });
+
+  test("store stage result includes buffered flag", async () => {
+    const localCache = mockLocalCache();
+    const { pipelineCtx } = buildCtx({ localCache });
+
+    const input: CaptureInput = {
+      messages: [{ role: "user", content: "I prefer TypeScript for all backend services" }],
+    };
+    const result = await captureStore.execute(input, pipelineCtx);
+
+    expect(result.action).toBe("continue");
+    if (result.action === "continue") {
+      expect(result.buffered).toBe(true);
+    }
+  });
+
+  test("store stage result has buffered=false when no cache", async () => {
+    const { pipelineCtx } = buildCtx({});
+
+    const input: CaptureInput = {
+      messages: [{ role: "user", content: "I prefer TypeScript for all backend services" }],
+    };
+    const result = await captureStore.execute(input, pipelineCtx);
+
+    expect(result.action).toBe("continue");
+    if (result.action === "continue") {
+      expect(result.buffered).toBe(false);
+    }
+  });
+
+  test("falls back to API when cache is disabled (not provided)", async () => {
+    const { pipelineCtx, client } = buildCtx({});
+
+    await runPipeline(capturePipeline, valuableMessages, pipelineCtx);
+
+    expect(client.store).toHaveBeenCalled();
+  });
+
+  test("falls back to API when bufferWrite throws", async () => {
+    const localCache: LocalCacheLike = {
+      bufferWrite: vi.fn(() => { throw new Error("disk full"); }),
+      bufferDepth: vi.fn(() => 0),
+    };
+    const { pipelineCtx, client } = buildCtx({ localCache });
+
+    await runPipeline(capturePipeline, valuableMessages, pipelineCtx);
+
+    // Should have fallen back to API for each message
+    expect(client.store).toHaveBeenCalled();
+  });
+
+  test("buffer receives correct metadata including scope and namespace", async () => {
+    const localCache = mockLocalCache();
+    const { pipelineCtx } = buildCtx({ localCache });
+
+    await runPipeline(capturePipeline, {
+      messages: [{ role: "user", content: "I prefer PostgreSQL for production databases" }],
+    }, pipelineCtx);
+
+    expect(localCache.bufferWrite).toHaveBeenCalledTimes(1);
+    const [content, metadata] = (localCache.bufferWrite as any).mock.calls[0];
+    expect(content).toContain("PostgreSQL");
+    expect(metadata.source).toBe("auto-capture");
+    expect(metadata.scope).toBeDefined();
+    expect(metadata.namespace).toBeDefined();
   });
 });


### PR DESCRIPTION
Sprint 2c. Buffer-first capture: writes to local SQLite buffer, SyncDaemon flushes in background. Closes #67.

## Summary
- Capture pipeline writes to `localCache.bufferWrite()` when available (<2ms)
- Returns immediately without blocking on API call
- Graceful fallback: if buffer write throws, falls back to direct API call
- `buffered` flag on `CaptureResult` indicates write path taken
- `LocalCacheLike` interface + `localCache` added to `PipelineContext`

## Test plan
- [x] 8 new buffer-first capture tests (writes to buffer, skips API, fallback on error, metadata correctness)
- [x] All 264 existing tests pass
- [ ] SyncDaemon flush verification (pending #68)

🤖 Generated with [Claude Code](https://claude.com/claude-code)