### PR TITLE
feat: PluginMemoryManager — fix openclaw status display (v0.17.0 #70)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -34,6 +34,7 @@ import {
 import { SessionResolver } from "./src/context/session-resolver.js";
 import { LocalCache } from "./src/cache/local-cache.js";
 import { SyncDaemon } from "./src/cache/sync-daemon.js";
+import { PluginMemoryManager } from "./src/cache/memory-manager.js";
 import type { LocalCacheConfig } from "./src/cache/types.js";
 
 // --- Hooks ---
@@ -379,6 +380,7 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
 
   let localCache: LocalCache | null = null;
   let syncDaemon: SyncDaemon | null = null;
+  let memoryManager: PluginMemoryManager | null = null;
 
   if (localCacheConfig.enabled) {
     try {
@@ -393,6 +395,15 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
       syncDaemon = new SyncDaemon(localCache, client, localCacheConfig);
       syncDaemon.start();
 
+      const vectorAvailable = localCacheConfig.vectorSearch.enabled;
+      memoryManager = new PluginMemoryManager(
+        localCache,
+        syncDaemon,
+        localCacheConfig,
+        vectorAvailable,
+        agentId || "main",
+      );
+
       // Initial pull on startup (non-blocking)
       syncDaemon.pull().catch((err) =>
         api.logger.warn?.(`memory-memoryrelay: initial sync failed: ${String(err)}`),
@@ -403,6 +414,7 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
       api.logger.warn?.(`memory-memoryrelay: local cache init failed, falling back to API-only: ${String(err)}`);
       localCache = null;
       syncDaemon = null;
+      memoryManager = null;
     }
   }
 
@@ -502,6 +514,17 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
   // `openclaw status` shows memory count, vector info, and provider details
   // instead of "unavailable". OpenClaw 2026.3.28+ calls this for all memory plugins.
   api.registerGatewayMethod?.("memory.probe", async ({ respond }) => {
+    // Use local PluginMemoryManager when available (v0.17.0+)
+    if (memoryManager) {
+      try {
+        const status = memoryManager.status();
+        respond(true, { available: true, ...status });
+        return;
+      } catch {
+        // Fall through to API-based probe
+      }
+    }
+
     try {
       const health = await client.health() as { status: string; embedding_info?: { dimension?: number } };
       const healthStatus = String(health.status).toLowerCase();
@@ -541,6 +564,16 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
         error: String(_err),
         custom: { endpoint: apiUrl, agentId, tier: "remote" },
       });
+    }
+  });
+
+  // getMemorySearchManager — exposes the PluginMemoryManager so OpenClaw's
+  // status scanner can call status(), probeVectorAvailability(), and close().
+  api.registerGatewayMethod?.("getMemorySearchManager", async ({ respond }) => {
+    if (memoryManager) {
+      respond(true, { manager: memoryManager });
+    } else {
+      respond(false, { error: "Local cache not initialized" });
     }
   });
 

--- a/src/cache/memory-manager.ts
+++ b/src/cache/memory-manager.ts
@@ -1,0 +1,84 @@
+import type { LocalCache } from "./local-cache.js";
+import type { SyncDaemon } from "./sync-daemon.js";
+import type { LocalCacheConfig } from "./types.js";
+
+/**
+ * MemoryProviderStatus — compatible with OpenClaw's MemorySearchManager interface.
+ * See: /usr/lib/node_modules/openclaw/dist/memory-search-B5CuuJZB.js
+ */
+export interface MemoryProviderStatus {
+  backend: "builtin" | "qmd";
+  provider: string;
+  files?: number;
+  chunks?: number;
+  dirty?: boolean;
+  fts?: { enabled: boolean; available: boolean };
+  vector?: { enabled: boolean; available?: boolean; dims?: number };
+  cache?: { enabled: boolean; entries?: number; maxEntries?: number };
+  custom?: Record<string, unknown>;
+}
+
+/**
+ * PluginMemoryManager wraps LocalCache + SyncDaemon to satisfy OpenClaw's
+ * MemorySearchManager interface, enabling `openclaw status` to display
+ * real memory counts and provider info.
+ */
+export class PluginMemoryManager {
+  private readonly cache: LocalCache;
+  private readonly syncDaemon: SyncDaemon;
+  private readonly vectorAvailable: boolean;
+  private readonly config: LocalCacheConfig;
+  private readonly agentId: string;
+
+  constructor(
+    cache: LocalCache,
+    syncDaemon: SyncDaemon,
+    config: LocalCacheConfig,
+    vectorAvailable: boolean,
+    agentId: string,
+  ) {
+    this.cache = cache;
+    this.syncDaemon = syncDaemon;
+    this.config = config;
+    this.vectorAvailable = vectorAvailable;
+    this.agentId = agentId;
+  }
+
+  status(): MemoryProviderStatus {
+    const stats = this.cache.stats();
+    return {
+      backend: "builtin",
+      provider: "memoryrelay",
+      files: stats.totalMemories,
+      chunks: stats.totalMemories,
+      dirty: stats.bufferDepth > 0,
+      fts: { enabled: true, available: true },
+      vector: {
+        enabled: this.vectorAvailable,
+        available: this.vectorAvailable,
+        dims: 768,
+      },
+      cache: {
+        enabled: true,
+        entries: stats.totalMemories,
+        maxEntries: this.config.maxLocalMemories,
+      },
+      custom: {
+        provider: "memoryrelay-api",
+        agentId: this.agentId,
+        bufferDepth: stats.bufferDepth,
+        lastSync: stats.lastSync,
+        syncActive: this.syncDaemon.isRunning(),
+      },
+    };
+  }
+
+  async probeVectorAvailability(): Promise<boolean> {
+    return this.vectorAvailable;
+  }
+
+  async close(): Promise<void> {
+    this.syncDaemon.stop();
+    this.cache.close();
+  }
+}

--- a/tests/cache/memory-manager.test.ts
+++ b/tests/cache/memory-manager.test.ts
@@ -1,0 +1,165 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from "vitest";
+import { LocalCache } from "../../src/cache/local-cache";
+import { SyncDaemon } from "../../src/cache/sync-daemon";
+import { PluginMemoryManager } from "../../src/cache/memory-manager";
+import type { LocalCacheConfig } from "../../src/cache/types";
+
+const DEFAULT_CONFIG: LocalCacheConfig = {
+  enabled: true,
+  dbPath: ":memory:",
+  syncIntervalMinutes: 5,
+  maxLocalMemories: 1000,
+  vectorSearch: { enabled: false, provider: "sqlite-vec" },
+  ttl: { hot: 72, warm: 168, cold: 720 },
+};
+
+function makeMemory(overrides: Record<string, unknown> = {}) {
+  return {
+    id: (overrides.id as string) ?? "mem-1",
+    content: (overrides.content as string) ?? "Test memory content",
+    agent_id: (overrides.agent_id as string) ?? "agent-1",
+    ...(overrides as Record<string, unknown>),
+  };
+}
+
+function createMockSyncDaemon(overrides: Partial<SyncDaemon> = {}): SyncDaemon {
+  return {
+    start: vi.fn(),
+    stop: vi.fn(),
+    isRunning: vi.fn().mockReturnValue(true),
+    lastError: vi.fn().mockReturnValue(null),
+    pull: vi.fn().mockResolvedValue({ added: 0, updated: 0 }),
+    push: vi.fn().mockResolvedValue({ flushed: 0, failed: 0 }),
+    ...overrides,
+  } as unknown as SyncDaemon;
+}
+
+describe("PluginMemoryManager", () => {
+  let cache: LocalCache;
+  let syncDaemon: SyncDaemon;
+  let manager: PluginMemoryManager;
+
+  beforeEach(() => {
+    cache = new LocalCache(":memory:", DEFAULT_CONFIG);
+    syncDaemon = createMockSyncDaemon();
+    manager = new PluginMemoryManager(cache, syncDaemon, DEFAULT_CONFIG, false, "agent-1");
+  });
+
+  afterEach(() => {
+    cache.close();
+  });
+
+  // --- status() ---
+
+  describe("status()", () => {
+    test("returns correct backend and provider", () => {
+      const status = manager.status();
+      expect(status.backend).toBe("builtin");
+      expect(status.provider).toBe("memoryrelay");
+    });
+
+    test("returns zero files/chunks for empty cache", () => {
+      const status = manager.status();
+      expect(status.files).toBe(0);
+      expect(status.chunks).toBe(0);
+    });
+
+    test("returns correct files/chunks count after inserts", () => {
+      cache.upsert(makeMemory({ id: "m1" }));
+      cache.upsert(makeMemory({ id: "m2" }));
+      cache.upsert(makeMemory({ id: "m3" }));
+      const status = manager.status();
+      expect(status.files).toBe(3);
+      expect(status.chunks).toBe(3);
+    });
+
+    test("dirty is false when buffer is empty", () => {
+      const status = manager.status();
+      expect(status.dirty).toBe(false);
+    });
+
+    test("dirty is true when buffer has pending entries", () => {
+      cache.bufferWrite("pending content", { scope: "long-term" });
+      const status = manager.status();
+      expect(status.dirty).toBe(true);
+    });
+
+    test("fts is enabled and available", () => {
+      const status = manager.status();
+      expect(status.fts).toEqual({ enabled: true, available: true });
+    });
+
+    test("vector is disabled when vectorAvailable is false", () => {
+      const status = manager.status();
+      expect(status.vector).toEqual({ enabled: false, available: false, dims: 768 });
+    });
+
+    test("vector is enabled when vectorAvailable is true", () => {
+      const mgr = new PluginMemoryManager(cache, syncDaemon, DEFAULT_CONFIG, true, "agent-1");
+      const status = mgr.status();
+      expect(status.vector).toEqual({ enabled: true, available: true, dims: 768 });
+    });
+
+    test("cache section reports correct entries and maxEntries", () => {
+      cache.upsert(makeMemory({ id: "m1" }));
+      cache.upsert(makeMemory({ id: "m2" }));
+      const status = manager.status();
+      expect(status.cache).toEqual({
+        enabled: true,
+        entries: 2,
+        maxEntries: 1000,
+      });
+    });
+
+    test("custom includes agentId", () => {
+      const status = manager.status();
+      expect(status.custom?.agentId).toBe("agent-1");
+    });
+
+    test("custom includes bufferDepth", () => {
+      cache.bufferWrite("buf1", {});
+      cache.bufferWrite("buf2", {});
+      const status = manager.status();
+      expect(status.custom?.bufferDepth).toBe(2);
+    });
+
+    test("custom includes syncActive from daemon", () => {
+      const status = manager.status();
+      expect(status.custom?.syncActive).toBe(true);
+    });
+
+    test("custom syncActive is false when daemon not running", () => {
+      const stoppedDaemon = createMockSyncDaemon({ isRunning: vi.fn().mockReturnValue(false) as unknown as () => boolean });
+      const mgr = new PluginMemoryManager(cache, stoppedDaemon, DEFAULT_CONFIG, false, "agent-1");
+      const status = mgr.status();
+      expect(status.custom?.syncActive).toBe(false);
+    });
+
+    test("custom includes lastSync as null initially", () => {
+      const status = manager.status();
+      expect(status.custom?.lastSync).toBeNull();
+    });
+  });
+
+  // --- probeVectorAvailability() ---
+
+  describe("probeVectorAvailability()", () => {
+    test("returns false when vector not available", async () => {
+      expect(await manager.probeVectorAvailability()).toBe(false);
+    });
+
+    test("returns true when vector is available", async () => {
+      const mgr = new PluginMemoryManager(cache, syncDaemon, DEFAULT_CONFIG, true, "agent-1");
+      expect(await mgr.probeVectorAvailability()).toBe(true);
+    });
+  });
+
+  // --- close() ---
+
+  describe("close()", () => {
+    test("stops sync daemon on close", async () => {
+      await manager.close();
+      expect(syncDaemon.stop).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements `PluginMemoryManager` class in `src/cache/memory-manager.ts` satisfying OpenClaw's `MemorySearchManager` interface (`status()`, `probeVectorAvailability()`, `close()`)
- Wires manager into `memory.probe` gateway method — local cache data used when available, falls back to API-based probe
- Registers `getMemorySearchManager` gateway method for status scanner integration

## Test plan
- [x] 17 new tests in `tests/cache/memory-manager.test.ts` covering status fields, vector availability, buffer dirty state, close behavior
- [x] All 395 tests pass (28 test files)

Sprint 4a. Closes #70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)