### PR TITLE
feat: observability — /memory-status + enriched probe (v0.17.0 #71)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -517,8 +517,20 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
     // Use local PluginMemoryManager when available (v0.17.0+)
     if (memoryManager) {
       try {
-        const status = memoryManager.status();
-        respond(true, { available: true, ...status });
+        const stats = memoryManager.cacheStats();
+        const daemonInfo = memoryManager.getSyncDaemonInfo();
+        respond(true, {
+          available: true,
+          provider: "memoryrelay",
+          memoryCount: stats.totalMemories,
+          tierBreakdown: stats.tierBreakdown,
+          bufferDepth: stats.bufferDepth,
+          syncActive: daemonInfo.running,
+          lastSync: stats.lastSync,
+          vector: { enabled: localCacheConfig.vectorSearch.enabled, dims: 768 },
+          fts: { enabled: true },
+          consecutiveErrors: daemonInfo.errors,
+        });
         return;
       } catch {
         // Fall through to API-based probe
@@ -901,7 +913,43 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
 
         if (statusReporter) {
           const report = statusReporter.buildReport(connectionStatus, reportConfig, { total_memories: memoryCount }, TOOL_GROUPS);
-          return { text: StatusReporter.formatReport(report) };
+          let text = StatusReporter.formatReport(report);
+
+          // Append local cache section when available
+          if (memoryManager) {
+            try {
+              const cacheStats = memoryManager.cacheStats();
+              const daemonInfo = memoryManager.getSyncDaemonInfo();
+              const cacheLines: string[] = [];
+              cacheLines.push("LOCAL CACHE");
+              const { hot, warm, cold } = cacheStats.tierBreakdown;
+              cacheLines.push(`  Total:     ${cacheStats.totalMemories} memories (hot: ${hot}, warm: ${warm}, cold: ${cold})`);
+              cacheLines.push(`  Buffer:    ${cacheStats.bufferDepth} entries pending sync`);
+              if (cacheStats.lastSync) {
+                const ago = StatusReporter.formatTimeAgo(new Date(cacheStats.lastSync));
+                cacheLines.push(`  Last sync: ${ago}`);
+              } else {
+                cacheLines.push("  Last sync: never");
+              }
+              const vecLabel = localCacheConfig.vectorSearch.enabled ? "ready (sqlite-vec, 768 dims)" : "disabled";
+              cacheLines.push(`  Vector:    ${vecLabel}`);
+              cacheLines.push("  FTS:       ready");
+              cacheLines.push("");
+              const daemonStatus = daemonInfo.running ? "running" : "stopped";
+              cacheLines.push(`SYNC DAEMON: ${daemonStatus}`);
+              cacheLines.push(`  Interval:  ${daemonInfo.intervalMinutes} minutes`);
+              cacheLines.push(`  Errors:    ${daemonInfo.errors} consecutive`);
+              if (daemonInfo.lastError) {
+                cacheLines.push(`  Last error: ${daemonInfo.lastError}`);
+              }
+              cacheLines.push("");
+              text += cacheLines.join("\n");
+            } catch {
+              // cache stats unavailable — skip section
+            }
+          }
+
+          return { text };
         }
         return { text: `MemoryRelay: ${isConnected ? "connected" : "disconnected"} | Endpoint: ${apiUrl} | Memories: ${memoryCount} | Agent: ${agentId}` };
       } catch (err) {

--- a/src/cache/local-cache.ts
+++ b/src/cache/local-cache.ts
@@ -151,6 +151,19 @@ export class LocalCache {
     return row.cnt;
   }
 
+  countByTier(): { hot: number; warm: number; cold: number } {
+    const rows = this.db
+      .prepare("SELECT tier, COUNT(*) as cnt FROM memories GROUP BY tier")
+      .all() as { tier: string; cnt: number }[];
+    const result = { hot: 0, warm: 0, cold: 0 };
+    for (const row of rows) {
+      if (row.tier === "hot" || row.tier === "warm" || row.tier === "cold") {
+        result[row.tier] = row.cnt;
+      }
+    }
+    return result;
+  }
+
   // --- Search ---
 
   search(
@@ -327,6 +340,7 @@ export class LocalCache {
 
   stats(): CacheStats {
     const totalMemories = this.count();
+    const tierBreakdown = this.countByTier();
     const bufferDepth = this.bufferDepth();
     const syncState = this.getSyncState();
     let dbSizeBytes = 0;
@@ -339,6 +353,7 @@ export class LocalCache {
     }
     return {
       totalMemories,
+      tierBreakdown,
       bufferDepth,
       lastSync: syncState.lastPull ?? syncState.lastPush ?? null,
       dbSizeBytes,

--- a/src/cache/memory-manager.ts
+++ b/src/cache/memory-manager.ts
@@ -1,6 +1,6 @@
 import type { LocalCache } from "./local-cache.js";
 import type { SyncDaemon } from "./sync-daemon.js";
-import type { LocalCacheConfig } from "./types.js";
+import type { CacheStats, LocalCacheConfig } from "./types.js";
 
 /**
  * MemoryProviderStatus — compatible with OpenClaw's MemorySearchManager interface.
@@ -67,9 +67,25 @@ export class PluginMemoryManager {
         provider: "memoryrelay-api",
         agentId: this.agentId,
         bufferDepth: stats.bufferDepth,
+        tierBreakdown: stats.tierBreakdown,
         lastSync: stats.lastSync,
         syncActive: this.syncDaemon.isRunning(),
+        consecutiveErrors: this.syncDaemon.getConsecutiveErrors(),
+        syncIntervalMinutes: this.config.syncIntervalMinutes,
       },
+    };
+  }
+
+  cacheStats(): CacheStats {
+    return this.cache.stats();
+  }
+
+  getSyncDaemonInfo(): { running: boolean; errors: number; intervalMinutes: number; lastError: string | null } {
+    return {
+      running: this.syncDaemon.isRunning(),
+      errors: this.syncDaemon.getConsecutiveErrors(),
+      intervalMinutes: this.config.syncIntervalMinutes,
+      lastError: this.syncDaemon.lastError(),
     };
   }
 

--- a/src/cache/sync-daemon.ts
+++ b/src/cache/sync-daemon.ts
@@ -50,6 +50,10 @@ export class SyncDaemon {
     return this._lastError;
   }
 
+  getConsecutiveErrors(): number {
+    return this.consecutiveErrors;
+  }
+
   async pull(): Promise<{ added: number; updated: number }> {
     let added = 0;
     let updated = 0;

--- a/src/cache/types.ts
+++ b/src/cache/types.ts
@@ -26,6 +26,7 @@ export interface SyncState {
 
 export interface CacheStats {
   totalMemories: number;
+  tierBreakdown: { hot: number; warm: number; cold: number };
   bufferDepth: number;
   lastSync: string | null;
   dbSizeBytes: number;

--- a/src/status-reporter.ts
+++ b/src/status-reporter.ts
@@ -280,7 +280,7 @@ export class StatusReporter {
   /**
    * Format time ago string
    */
-  private static formatTimeAgo(date: Date): string {
+  static formatTimeAgo(date: Date): string {
     const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
 
     if (seconds < 60) return `${seconds} seconds ago`;

--- a/tests/cache/memory-manager.test.ts
+++ b/tests/cache/memory-manager.test.ts
@@ -28,6 +28,7 @@ function createMockSyncDaemon(overrides: Partial<SyncDaemon> = {}): SyncDaemon {
     stop: vi.fn(),
     isRunning: vi.fn().mockReturnValue(true),
     lastError: vi.fn().mockReturnValue(null),
+    getConsecutiveErrors: vi.fn().mockReturnValue(0),
     pull: vi.fn().mockResolvedValue({ added: 0, updated: 0 }),
     push: vi.fn().mockResolvedValue({ flushed: 0, failed: 0 }),
     ...overrides,


### PR DESCRIPTION
## Summary
Sprint 4b. Enhanced /memory-status with cache stats, enriched memory.probe.

- `/memory-status` now shows local cache section: total memories with hot/warm/cold breakdown, buffer depth, last sync, vector/FTS availability, sync daemon status
- `memory.probe` gateway returns enriched response with `memoryCount`, `tierBreakdown`, `bufferDepth`, `syncActive`, `lastSync`, `vector`, `fts`
- Added `countByTier()` to LocalCache, `getConsecutiveErrors()` to SyncDaemon, `cacheStats()`/`getSyncDaemonInfo()` to PluginMemoryManager
- Made `StatusReporter.formatTimeAgo` public for reuse

## Test plan
- [x] All 395 tests pass
- [x] Works when cache disabled (falls through to API-only probe path)

Closes #71.