### PR TITLE
chore: v0.17.2 housekeeping — openclaw.hooks, RELEASING.md (#85, #88)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2] - 2026-03-29
+
+### Fixed
+- **JSDoc header comment version**: Updated top-of-file version comment to 0.17.2 (#85)
+- **Add `openclaw.hooks: []` to package.json**: Silences `package.json missing openclaw.hooks` warning during `openclaw plugins install` (#88)
+
+### Added
+- **RELEASING.md**: Release checklist documenting all 6 version locations and publish workflow (#85)
+
 ## [0.17.1] - 2026-03-29
 
 ### Fixed

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,20 @@
+# Release Checklist
+
+Before tagging vX.Y.Z:
+
+- [ ] Update version in ALL 6 locations:
+  - package.json → version
+  - package-lock.json → version
+  - openclaw.plugin.json → version
+  - index.ts → JSDoc header '* Version: X.Y.Z'
+  - index.ts → startup log string 'plugin vX.Y.Z loaded'
+  - src/client/memoryrelay-client.ts → User-Agent header
+- [ ] CHANGELOG.md → [X.Y.Z] - YYYY-MM-DD entry complete
+- [ ] npm test passes (all tests green)
+- [ ] git tag vX.Y.Z && git push origin vX.Y.Z (CI/CD auto-publishes to npm)
+
+## Note on plugins install
+openclaw plugins install refuses to overwrite existing extensions.
+Users must: rm -rf ~/.openclaw/extensions/plugin-memoryrelay-ai first.
+Workaround command:
+  mkdir /tmp/mr && cd /tmp/mr && npm pack @memoryrelay/plugin-memoryrelay-ai@LATEST && tar -xzf *.tgz && rm -rf ~/.openclaw/extensions/plugin-memoryrelay-ai && cp -r package ~/.openclaw/extensions/plugin-memoryrelay-ai && rm -rf /tmp/mr && cd ~ && openclaw gateway restart

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 /**
  * OpenClaw Memory Plugin - MemoryRelay
- * Version: 0.17.1
+ * Version: 0.17.2
  *
  * Long-term memory with vector search using MemoryRelay API.
  * Provides auto-recall and auto-capture via lifecycle hooks.
@@ -472,7 +472,7 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
   // ========================================================================
 
   api.logger.info?.(
-    `memory-memoryrelay: plugin v0.17.1 loaded (${Object.values(TOOL_GROUPS).flat().length} tools, autoRecall: ${pluginConfig.autoRecall}, autoCapture: ${autoCaptureConfig.enabled ? autoCaptureConfig.tier : "off"}, debug: ${debugEnabled})`,
+    `memory-memoryrelay: plugin v0.17.2 loaded (${Object.values(TOOL_GROUPS).flat().length} tools, autoRecall: ${pluginConfig.autoRecall}, autoCapture: ${autoCaptureConfig.enabled ? autoCaptureConfig.tier : "off"}, debug: ${debugEnabled})`,
   );
 
   // ========================================================================

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,8 +2,8 @@
   "id": "plugin-memoryrelay-ai",
   "kind": "memory",
   "name": "MemoryRelay AI",
-  "description": "MemoryRelay v0.17.1 - Long-term memory with pipeline architecture, 42 tools, 17 commands, V2 async, sessions, decisions, patterns & projects (api.memoryrelay.net)",
-  "version": "0.17.1",
+  "description": "MemoryRelay v0.17.2 - Long-term memory with pipeline architecture, 42 tools, 17 commands, V2 async, sessions, decisions, patterns & projects (api.memoryrelay.net)",
+  "version": "0.17.2",
   "uiHints": {
     "apiKey": {
       "label": "MemoryRelay API Key",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memoryrelay/plugin-memoryrelay-ai",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memoryrelay/plugin-memoryrelay-ai",
-      "version": "0.17.1",
+      "version": "0.17.2",
       "bundleDependencies": [
         "better-sqlite3"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoryrelay/plugin-memoryrelay-ai",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "description": "OpenClaw memory plugin for MemoryRelay API - 42 tools, 17 commands, V2 async, sessions, decisions, patterns, projects & semantic search",
   "type": "module",
   "main": "index.ts",
@@ -42,7 +42,8 @@
   "openclaw": {
     "extensions": [
       "index.ts"
-    ]
+    ],
+    "hooks": []
   },
   "files": [
     "index.ts",

--- a/src/client/memoryrelay-client.ts
+++ b/src/client/memoryrelay-client.ts
@@ -153,7 +153,7 @@ export class MemoryRelayClient implements IMemoryRelayClient {
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${this.apiKey}`,
-            "User-Agent": "openclaw-memory-memoryrelay/0.17.1",
+            "User-Agent": "openclaw-memory-memoryrelay/0.17.2",
           },
           body: body ? JSON.stringify(body) : undefined,
         },


### PR DESCRIPTION
Fixes #85 (JSDoc header, RELEASING.md) and #88 (openclaw.hooks empty array to silence install warning). No functional changes.

## Summary
- **Version bump 0.17.1 → 0.17.2** across all 6 locations (package.json, package-lock.json, openclaw.plugin.json, index.ts JSDoc + startup log, User-Agent header)
- **Add `openclaw.hooks: []`** to package.json to silence `openclaw plugins install` warning
- **Add RELEASING.md** with release checklist documenting all version locations and publish workflow
- **CHANGELOG.md** updated with [0.17.2] entry

## Test plan
- [x] All 395 tests pass (`npm test`)
- [ ] Verify `openclaw plugins install` no longer warns about missing hooks
- [ ] Verify startup log shows `plugin v0.17.2 loaded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)