### PR TITLE
feat: auto session lifecycle (v0.18.0 #90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-03-30
+
+### Added
+- **Auto session lifecycle**: `before_agent_start` hook now calls `session_start` and `project_context` automatically, injecting hot memories, decisions, and patterns into the prompt (#90)
+- **Auto decision extraction**: `agent_end` hook detects decisions from conversation using keyword heuristics and records them via `decision_record` (#90)
+- **Auto session end**: `agent_end` hook calls `session_end` with a generated summary from the last significant assistant messages (#90)
+- **Project slug detection**: Resolves project from `defaultProject` config, `MEMORYRELAY_DEFAULT_PROJECT` env var, or working directory name (#90)
+- **Shared auto-session store**: `src/hooks/auto-session-store.ts` provides cross-hook session state and decision keywords (#90)
+
 ## [0.17.2] - 2026-03-29
 
 ### Fixed

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 /**
  * OpenClaw Memory Plugin - MemoryRelay
- * Version: 0.17.2
+ * Version: 0.18.0
  *
  * Long-term memory with vector search using MemoryRelay API.
  * Provides auto-recall and auto-capture via lifecycle hooks.
@@ -444,7 +444,7 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
   // Register Hooks (8 modules)
   // ========================================================================
 
-  registerBeforeAgentStart(api, pluginConfig, isToolEnabled, defaultProject);
+  registerBeforeAgentStart(api, pluginConfig, client, isToolEnabled, defaultProject);
   registerBeforePromptBuild(api, pluginConfig, client, sessionResolver, localCache, syncDaemon);
   registerAgentEnd(api, pluginConfig, client, sessionResolver, localCache, syncDaemon);
   registerSessionLifecycle(api, pluginConfig, client, agentId, defaultProject, sessionResolver);
@@ -472,7 +472,7 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
   // ========================================================================
 
   api.logger.info?.(
-    `memory-memoryrelay: plugin v0.17.2 loaded (${Object.values(TOOL_GROUPS).flat().length} tools, autoRecall: ${pluginConfig.autoRecall}, autoCapture: ${autoCaptureConfig.enabled ? autoCaptureConfig.tier : "off"}, debug: ${debugEnabled})`,
+    `memory-memoryrelay: plugin v0.18.0 loaded (${Object.values(TOOL_GROUPS).flat().length} tools, autoRecall: ${pluginConfig.autoRecall}, autoCapture: ${autoCaptureConfig.enabled ? autoCaptureConfig.tier : "off"}, debug: ${debugEnabled})`,
   );
 
   // ========================================================================

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,8 +2,8 @@
   "id": "plugin-memoryrelay-ai",
   "kind": "memory",
   "name": "MemoryRelay AI",
-  "description": "MemoryRelay v0.17.2 - Long-term memory with pipeline architecture, 42 tools, 17 commands, V2 async, sessions, decisions, patterns & projects (api.memoryrelay.net)",
-  "version": "0.17.2",
+  "description": "MemoryRelay v0.18.0 - Long-term memory with pipeline architecture, 42 tools, 17 commands, V2 async, sessions, decisions, patterns & projects (api.memoryrelay.net)",
+  "version": "0.18.0",
   "uiHints": {
     "apiKey": {
       "label": "MemoryRelay API Key",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@memoryrelay/plugin-memoryrelay-ai",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memoryrelay/plugin-memoryrelay-ai",
-      "version": "0.17.2",
+      "version": "0.18.0",
       "bundleDependencies": [
         "better-sqlite3"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoryrelay/plugin-memoryrelay-ai",
-  "version": "0.17.2",
+  "version": "0.18.0",
   "description": "OpenClaw memory plugin for MemoryRelay API - 42 tools, 17 commands, V2 async, sessions, decisions, patterns, projects & semantic search",
   "type": "module",
   "main": "index.ts",

--- a/src/client/memoryrelay-client.ts
+++ b/src/client/memoryrelay-client.ts
@@ -153,7 +153,7 @@ export class MemoryRelayClient implements IMemoryRelayClient {
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${this.apiKey}`,
-            "User-Agent": "openclaw-memory-memoryrelay/0.17.2",
+            "User-Agent": "openclaw-memory-memoryrelay/0.18.0",
           },
           body: body ? JSON.stringify(body) : undefined,
         },

--- a/src/hooks/agent-end.ts
+++ b/src/hooks/agent-end.ts
@@ -4,6 +4,65 @@ import type { PluginConfig, MemoryRelayClient, ConversationMessage, SessionResol
 import { buildRequestContext } from "../context/request-context.js";
 import { runPipeline } from "../pipelines/runner.js";
 import { capturePipeline } from "../pipelines/capture/index.js";
+import { autoSessionMap, DECISION_KEYWORDS } from "./auto-session-store.js";
+
+/**
+ * Extract potential decisions from conversation messages using keyword heuristics.
+ * Returns an array of { title, rationale } for each detected decision.
+ */
+export function extractDecisions(
+  messages: ConversationMessage[],
+): Array<{ title: string; rationale: string }> {
+  const decisions: Array<{ title: string; rationale: string }> = [];
+  const seen = new Set<string>();
+
+  for (const msg of messages) {
+    if (msg.role !== "assistant") continue;
+    const content = msg.content;
+    const lower = content.toLowerCase();
+
+    for (const keyword of DECISION_KEYWORDS) {
+      if (!lower.includes(keyword)) continue;
+
+      // Find the sentence containing the keyword
+      const sentences = content.split(/[.!?\n]+/).filter((s) => s.trim().length > 10);
+      for (const sentence of sentences) {
+        if (!sentence.toLowerCase().includes(keyword)) continue;
+        const trimmed = sentence.trim();
+        // Avoid duplicates and very long passages
+        if (trimmed.length > 500) continue;
+        const key = trimmed.slice(0, 80).toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+
+        decisions.push({
+          title: trimmed.slice(0, 200),
+          rationale: `Auto-detected from conversation (keyword: "${keyword}"): ${trimmed}`,
+        });
+        break; // One decision per keyword per message
+      }
+      if (decisions.length >= 5) break; // Cap at 5 decisions per session
+    }
+    if (decisions.length >= 5) break;
+  }
+  return decisions;
+}
+
+/**
+ * Generate a summary from the last few significant assistant messages.
+ */
+export function generateSessionSummary(messages: ConversationMessage[]): string {
+  const assistantMessages = messages
+    .filter((m) => m.role === "assistant" && m.content.length > 30)
+    .slice(-3);
+
+  if (assistantMessages.length === 0) return "Session completed.";
+
+  return assistantMessages
+    .map((m) => m.content.slice(0, 300))
+    .join(" | ")
+    .slice(0, 800);
+}
 
 export function registerAgentEnd(
   api: OpenClawPluginApi,
@@ -18,28 +77,67 @@ export function registerAgentEnd(
   api.on("agent_end", async (event) => {
     if (!event.success || !event.messages || event.messages.length === 0) return;
 
-    try {
-      const messages: ConversationMessage[] = [];
-      for (const msg of event.messages) {
-        if (!msg || typeof msg !== "object") continue;
-        const msgObj = msg as Record<string, unknown>;
-        const role = msgObj.role as string;
-        if (role !== "user" && role !== "assistant") continue;
+    // Parse messages first (shared by session lifecycle and capture pipeline)
+    const messages: ConversationMessage[] = [];
+    for (const msg of event.messages) {
+      if (!msg || typeof msg !== "object") continue;
+      const msgObj = msg as Record<string, unknown>;
+      const role = msgObj.role as string;
+      if (role !== "user" && role !== "assistant") continue;
 
-        const content = msgObj.content;
-        if (typeof content === "string") {
-          messages.push({ role: role as "user" | "assistant", content });
-        } else if (Array.isArray(content)) {
-          for (const block of content) {
-            if (block && typeof block === "object" && (block as any).type === "text" && (block as any).text) {
-              messages.push({ role: role as "user" | "assistant", content: (block as any).text });
-            }
+      const content = msgObj.content;
+      if (typeof content === "string") {
+        messages.push({ role: role as "user" | "assistant", content });
+      } else if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block && typeof block === "object" && (block as any).type === "text" && (block as any).text) {
+            messages.push({ role: role as "user" | "assistant", content: (block as any).text });
           }
         }
       }
+    }
 
-      if (messages.length === 0) return;
+    if (messages.length === 0) return;
 
+    // --- Auto session lifecycle: decisions + session_end ---
+    const sessionKey = event.ctx?.sessionKey || event.sessionId || "";
+    const sessionId = autoSessionMap.get(sessionKey);
+
+    if (sessionId) {
+      try {
+        // Extract and record decisions
+        const decisions = extractDecisions(messages);
+        const projectSlug = config.defaultProject || process.env.MEMORYRELAY_DEFAULT_PROJECT;
+
+        for (const decision of decisions) {
+          try {
+            await client.recordDecision(
+              decision.title,
+              decision.rationale,
+              undefined,
+              projectSlug,
+              ["auto-detected"],
+              undefined,
+              { source: "auto-session-lifecycle", session_id: sessionId },
+            );
+          } catch (err) {
+            api.logger.warn?.(`memory-memoryrelay: auto decision_record failed: ${String(err)}`);
+          }
+        }
+
+        // End session with summary
+        const summary = generateSessionSummary(messages);
+        await client.endSession(sessionId, summary);
+        api.logger.debug?.(`memory-memoryrelay: auto-session ended ${sessionId}`);
+      } catch (err) {
+        api.logger.warn?.(`memory-memoryrelay: auto session_end failed (non-blocking): ${String(err)}`);
+      } finally {
+        autoSessionMap.delete(sessionKey);
+      }
+    }
+
+    // --- Existing capture pipeline ---
+    try {
       const requestCtx = buildRequestContext(event, config);
       const pipelineCtx = { requestCtx, config, client, sessionResolver, localCache, syncDaemon };
       await runPipeline(capturePipeline, { messages }, pipelineCtx);

--- a/src/hooks/auto-session-store.ts
+++ b/src/hooks/auto-session-store.ts
@@ -1,0 +1,16 @@
+// src/hooks/auto-session-store.ts
+// Shared state between before-agent-start and agent-end hooks for auto session lifecycle.
+
+/** Maps agent session key → MemoryRelay session ID */
+export const autoSessionMap = new Map<string, string>();
+
+/** Decision detection keywords used in agent-end heuristics */
+export const DECISION_KEYWORDS = [
+  "decided",
+  "going with",
+  "architecture",
+  "we will",
+  "won't",
+  "instead of",
+  "chosen",
+];

--- a/src/hooks/before-agent-start.ts
+++ b/src/hooks/before-agent-start.ts
@@ -1,10 +1,28 @@
 // src/hooks/before-agent-start.ts
+import { basename } from "node:path";
 import type { OpenClawPluginApi } from "openclaw/plugin-sdk";
-import type { PluginConfig } from "../pipelines/types.js";
+import type { PluginConfig, MemoryRelayClient } from "../pipelines/types.js";
+import { autoSessionMap } from "./auto-session-store.js";
+
+/**
+ * Resolve project slug from config, env, or working directory name.
+ */
+function resolveProjectSlug(config: PluginConfig, defaultProject: string | undefined): string | undefined {
+  if (defaultProject) return defaultProject;
+  if (config.defaultProject) return config.defaultProject;
+  const envProject = process.env.MEMORYRELAY_DEFAULT_PROJECT;
+  if (envProject) return envProject;
+  try {
+    return basename(process.cwd());
+  } catch {
+    return undefined;
+  }
+}
 
 export function registerBeforeAgentStart(
   api: OpenClawPluginApi,
   config: PluginConfig,
+  client: MemoryRelayClient,
   isToolEnabled: (name: string) => boolean,
   defaultProject: string | undefined,
 ): void {
@@ -21,6 +39,62 @@ export function registerBeforeAgentStart(
           `memory-memoryrelay: skipping for excluded channel: ${channelId}`,
         );
         return;
+      }
+    }
+
+    // --- Auto session lifecycle: session_start + project_context ---
+    const projectSlug = resolveProjectSlug(config, defaultProject);
+    let projectContextBlock = "";
+
+    try {
+      const sessionKey = event.ctx?.sessionKey || event.sessionId || "";
+
+      // Start a tracked session (non-blocking — we await but don't let failure block the turn)
+      const today = new Date().toISOString().slice(0, 10);
+      const sessionResult = await client.startSession(
+        `Auto session ${today}`,
+        projectSlug,
+        { source: "openclaw-plugin", trigger: "before_agent_start" },
+      );
+
+      if (sessionResult?.id && sessionKey) {
+        autoSessionMap.set(sessionKey, sessionResult.id);
+        api.logger.debug?.(`memory-memoryrelay: auto-session started ${sessionResult.id}`);
+      }
+    } catch (err) {
+      api.logger.warn?.(`memory-memoryrelay: auto session_start failed (non-blocking): ${String(err)}`);
+    }
+
+    // Load project context (hot memories, decisions, patterns)
+    if (projectSlug) {
+      try {
+        const ctx = await client.getProjectContext(projectSlug);
+        if (ctx) {
+          const parts: string[] = [];
+          if (ctx.hot_memories?.length) {
+            parts.push("### Hot Memories");
+            for (const m of ctx.hot_memories.slice(0, 10)) {
+              parts.push(`- ${m.content ?? m}`);
+            }
+          }
+          if (ctx.recent_decisions?.length) {
+            parts.push("### Active Decisions");
+            for (const d of ctx.recent_decisions.slice(0, 5)) {
+              parts.push(`- **${d.title}**: ${(d.rationale ?? "").slice(0, 200)}`);
+            }
+          }
+          if (ctx.active_patterns?.length) {
+            parts.push("### Adopted Patterns");
+            for (const p of ctx.active_patterns.slice(0, 5)) {
+              parts.push(`- **${p.title}**: ${(p.description ?? "").slice(0, 150)}`);
+            }
+          }
+          if (parts.length > 0) {
+            projectContextBlock = `\n\n## Project Context (${projectSlug})\n\n${parts.join("\n")}`;
+          }
+        }
+      } catch (err) {
+        api.logger.warn?.(`memory-memoryrelay: project_context failed (non-blocking): ${String(err)}`);
       }
     }
 
@@ -102,7 +176,7 @@ export function registerBeforeAgentStart(
 
     const workflowInstructions = lines.join("\n");
 
-    const prependContext = `<memoryrelay-workflow>\n${workflowInstructions}\n</memoryrelay-workflow>`;
+    const prependContext = `<memoryrelay-workflow>\n${workflowInstructions}${projectContextBlock}\n</memoryrelay-workflow>`;
 
     return { prependContext };
   });

--- a/src/pipelines/types.ts
+++ b/src/pipelines/types.ts
@@ -109,7 +109,18 @@ export interface MemoryRelayClient {
     project?: string,
     metadata?: Record<string, string>,
   ): Promise<{ id: string }>;
+  startSession(title?: string, project?: string, metadata?: Record<string, string>): Promise<{ id: string }>;
   endSession(sessionId: string, summary?: string): Promise<void>;
+  getProjectContext(project: string): Promise<any>;
+  recordDecision(
+    title: string,
+    rationale: string,
+    alternatives?: string,
+    project?: string,
+    tags?: string[],
+    status?: string,
+    metadata?: Record<string, string>,
+  ): Promise<any>;
 }
 
 export interface SessionResolverLike {

--- a/tests/context/session-resolver.test.ts
+++ b/tests/context/session-resolver.test.ts
@@ -10,7 +10,10 @@ function mockClient(): MemoryRelayClient {
     store: vi.fn(),
     list: vi.fn(),
     getOrCreateSession: vi.fn(async () => ({ id: `session-${nextId++}` })),
+    startSession: vi.fn(async () => ({ id: `session-${nextId++}` })),
     endSession: vi.fn(async () => {}),
+    getProjectContext: vi.fn(async () => ({})),
+    recordDecision: vi.fn(async () => ({})),
   };
 }
 

--- a/tests/hooks/session-lifecycle.test.ts
+++ b/tests/hooks/session-lifecycle.test.ts
@@ -1,0 +1,416 @@
+// tests/hooks/session-lifecycle.test.ts
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { registerBeforeAgentStart } from "../../src/hooks/before-agent-start.js";
+import { registerAgentEnd, extractDecisions, generateSessionSummary } from "../../src/hooks/agent-end.js";
+import { autoSessionMap } from "../../src/hooks/auto-session-store.js";
+import type { PluginConfig, MemoryRelayClient, ConversationMessage } from "../../src/pipelines/types.js";
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function mockClient(): MemoryRelayClient & {
+  startSession: ReturnType<typeof vi.fn>;
+  endSession: ReturnType<typeof vi.fn>;
+  getProjectContext: ReturnType<typeof vi.fn>;
+  recordDecision: ReturnType<typeof vi.fn>;
+  getOrCreateSession: ReturnType<typeof vi.fn>;
+} {
+  return {
+    search: vi.fn(async () => []),
+    store: vi.fn(async () => ({ id: "mem-1", content: "", agent_id: "", user_id: "", metadata: {}, entities: [], created_at: "", updated_at: "" })),
+    list: vi.fn(async () => []),
+    getOrCreateSession: vi.fn(async () => ({ id: "session-existing" })),
+    startSession: vi.fn(async () => ({ id: "auto-session-1" })),
+    endSession: vi.fn(async () => {}),
+    getProjectContext: vi.fn(async () => ({
+      hot_memories: [{ content: "Project uses TypeScript" }],
+      recent_decisions: [{ title: "Use Vitest", rationale: "Fast and modern" }],
+      active_patterns: [{ title: "Pipeline pattern", description: "All operations use pipelines" }],
+    })),
+    recordDecision: vi.fn(async () => ({ id: "dec-1" })),
+  };
+}
+
+type HookHandler = (event: any) => Promise<any>;
+
+function mockApi(): {
+  api: any;
+  handlers: Map<string, HookHandler>;
+} {
+  const handlers = new Map<string, HookHandler>();
+  const api = {
+    on: vi.fn((event: string, handler: HookHandler) => {
+      handlers.set(event, handler);
+    }),
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn(),
+      info: vi.fn(),
+    },
+  };
+  return { api, handlers };
+}
+
+const baseConfig: PluginConfig = {
+  defaultProject: "test-project",
+  autoCapture: { enabled: true, tier: "smart" },
+};
+
+// ============================================================================
+// before-agent-start: auto session lifecycle
+// ============================================================================
+
+describe("before-agent-start: auto session lifecycle", () => {
+  beforeEach(() => {
+    autoSessionMap.clear();
+  });
+  afterEach(() => {
+    autoSessionMap.clear();
+  });
+
+  test("calls session_start on before_agent_start", async () => {
+    const { api, handlers } = mockApi();
+    const client = mockClient();
+    registerBeforeAgentStart(api, baseConfig, client, () => true, "test-project");
+
+    const handler = handlers.get("before_agent_start")!;
+    await handler({
+      prompt: "Implement the feature",
+      ctx: { sessionKey: "agent:abc:main" },
+    });
+
+    expect(client.startSession).toHaveBeenCalledTimes(1);
+    expect(client.startSession).toHaveBeenCalledWith(
+      expect.stringContaining("Auto session"),
+      "test-project",
+      expect.objectContaining({ source: "openclaw-plugin" }),
+    );
+  });
+
+  test("calls project_context with detected project", async () => {
+    const { api, handlers } = mockApi();
+    const client = mockClient();
+    registerBeforeAgentStart(api, baseConfig, client, () => true, "test-project");
+
+    const handler = handlers.get("before_agent_start")!;
+    await handler({
+      prompt: "Implement the feature",
+      ctx: { sessionKey: "agent:abc:main" },
+    });
+
+    expect(client.getProjectContext).toHaveBeenCalledTimes(1);
+    expect(client.getProjectContext).toHaveBeenCalledWith("test-project");
+  });
+
+  test("stores session_id in autoSessionMap", async () => {
+    const { api, handlers } = mockApi();
+    const client = mockClient();
+    registerBeforeAgentStart(api, baseConfig, client, () => true, "test-project");
+
+    const handler = handlers.get("before_agent_start")!;
+    await handler({
+      prompt: "Implement the feature",
+      ctx: { sessionKey: "agent:abc:main" },
+    });
+
+    expect(autoSessionMap.get("agent:abc:main")).toBe("auto-session-1");
+  });
+
+  test("injects project context into prependContext", async () => {
+    const { api, handlers } = mockApi();
+    const client = mockClient();
+    registerBeforeAgentStart(api, baseConfig, client, () => true, "test-project");
+
+    const handler = handlers.get("before_agent_start")!;
+    const result = await handler({
+      prompt: "Implement the feature",
+      ctx: { sessionKey: "agent:abc:main" },
+    });
+
+    expect(result.prependContext).toContain("Project Context (test-project)");
+    expect(result.prependContext).toContain("Hot Memories");
+    expect(result.prependContext).toContain("Project uses TypeScript");
+  });
+
+  test("session_start failure does not block the turn", async () => {
+    const { api, handlers } = mockApi();
+    const client = mockClient();
+    client.startSession.mockRejectedValue(new Error("network error"));
+    registerBeforeAgentStart(api, baseConfig, client, () => true, "test-project");
+
+    const handler = handlers.get("before_agent_start")!;
+    const result = await handler({
+      prompt: "Implement the feature",
+      ctx: { sessionKey: "agent:abc:main" },
+    });
+
+    // Should still return workflow instructions
+    expect(result.prependContext).toContain("memoryrelay-workflow");
+    expect(api.logger.warn).toHaveBeenCalled();
+  });
+
+  test("project_context failure does not block the turn", async () => {
+    const { api, handlers } = mockApi();
+    const client = mockClient();
+    client.getProjectContext.mockRejectedValue(new Error("project not found"));
+    registerBeforeAgentStart(api, baseConfig, client, () => true, "test-project");
+
+    const handler = handlers.get("before_agent_start")!;
+    const result = await handler({
+      prompt: "Implement the feature",
+      ctx: { sessionKey: "agent:abc:main" },
+    });
+
+    expect(result.prependContext).toContain("memoryrelay-workflow");
+    expect(result.prependContext).not.toContain("Project Context");
+  });
+
+  test("detects project from env when no defaultProject", async () => {
+    const { api, handlers } = mockApi();
+    const client = mockClient();
+    const configNoProject: PluginConfig = { autoCapture: { enabled: true, tier: "smart" } };
+
+    const originalEnv = process.env.MEMORYRELAY_DEFAULT_PROJECT;
+    process.env.MEMORYRELAY_DEFAULT_PROJECT = "env-project";
+    try {
+      registerBeforeAgentStart(api, configNoProject, client, () => true, undefined);
+      const handler = handlers.get("before_agent_start")!;
+      await handler({
+        prompt: "Implement the feature",
+        ctx: { sessionKey: "agent:abc:main" },
+      });
+
+      expect(client.getProjectContext).toHaveBeenCalledWith("env-project");
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.MEMORYRELAY_DEFAULT_PROJECT;
+      } else {
+        process.env.MEMORYRELAY_DEFAULT_PROJECT = originalEnv;
+      }
+    }
+  });
+
+  test("skips short prompts", async () => {
+    const { api, handlers } = mockApi();
+    const client = mockClient();
+    registerBeforeAgentStart(api, baseConfig, client, () => true, "test-project");
+
+    const handler = handlers.get("before_agent_start")!;
+    const result = await handler({ prompt: "hi" });
+
+    expect(result).toBeUndefined();
+    expect(client.startSession).not.toHaveBeenCalled();
+  });
+});
+
+// ============================================================================
+// agent-end: auto session lifecycle
+// ============================================================================
+
+describe("agent-end: auto session lifecycle", () => {
+  beforeEach(() => {
+    autoSessionMap.clear();
+  });
+  afterEach(() => {
+    autoSessionMap.clear();
+  });
+
+  test("calls session_end on agent_end when session was started", async () => {
+    const { api, handlers } = mockApi();
+    const client = mockClient();
+    autoSessionMap.set("agent:abc:main", "auto-session-1");
+
+    registerAgentEnd(api, baseConfig, client);
+
+    const handler = handlers.get("agent_end")!;
+    await handler({
+      success: true,
+      ctx: { sessionKey: "agent:abc:main" },
+      messages: [
+        { role: "user", content: "Fix the bug" },
+        { role: "assistant", content: "I fixed the null pointer exception in the data processor by adding proper validation." },
+      ],
+    });
+
+    expect(client.endSession).toHaveBeenCalledTimes(1);
+    expect(client.endSession).toHaveBeenCalledWith("auto-session-1", expect.any(String));
+  });
+
+  test("no session_end if no session was started", async () => {
+    const { api, handlers } = mockApi();
+    const client = mockClient();
+    // autoSessionMap is empty — no session started
+
+    registerAgentEnd(api, baseConfig, client);
+
+    const handler = handlers.get("agent_end")!;
+    await handler({
+      success: true,
+      ctx: { sessionKey: "agent:abc:main" },
+      messages: [
+        { role: "user", content: "Fix the bug" },
+        { role: "assistant", content: "Done fixing the bug." },
+      ],
+    });
+
+    expect(client.endSession).not.toHaveBeenCalled();
+  });
+
+  test("cleans up session from autoSessionMap after end", async () => {
+    const { api, handlers } = mockApi();
+    const client = mockClient();
+    autoSessionMap.set("agent:abc:main", "auto-session-1");
+
+    registerAgentEnd(api, baseConfig, client);
+
+    const handler = handlers.get("agent_end")!;
+    await handler({
+      success: true,
+      ctx: { sessionKey: "agent:abc:main" },
+      messages: [
+        { role: "user", content: "Do something" },
+        { role: "assistant", content: "Done with the implementation task." },
+      ],
+    });
+
+    expect(autoSessionMap.has("agent:abc:main")).toBe(false);
+  });
+
+  test("session_end failure is caught gracefully", async () => {
+    const { api, handlers } = mockApi();
+    const client = mockClient();
+    client.endSession.mockRejectedValue(new Error("session not found"));
+    autoSessionMap.set("agent:abc:main", "auto-session-1");
+
+    registerAgentEnd(api, baseConfig, client);
+
+    const handler = handlers.get("agent_end")!;
+    // Should not throw
+    await handler({
+      success: true,
+      ctx: { sessionKey: "agent:abc:main" },
+      messages: [
+        { role: "user", content: "Do something" },
+        { role: "assistant", content: "Done with the implementation task." },
+      ],
+    });
+
+    expect(api.logger.warn).toHaveBeenCalled();
+    // Should still clean up
+    expect(autoSessionMap.has("agent:abc:main")).toBe(false);
+  });
+});
+
+// ============================================================================
+// Decision extraction heuristics
+// ============================================================================
+
+describe("extractDecisions", () => {
+  test("detects 'we decided' keyword", () => {
+    const messages: ConversationMessage[] = [
+      { role: "assistant", content: "We decided to use PostgreSQL for the database layer because of its JSON support." },
+    ];
+    const decisions = extractDecisions(messages);
+    expect(decisions.length).toBe(1);
+    expect(decisions[0].title).toContain("decided");
+  });
+
+  test("detects 'going with' keyword", () => {
+    const messages: ConversationMessage[] = [
+      { role: "assistant", content: "After reviewing the options, we're going with Redis for the cache layer." },
+    ];
+    const decisions = extractDecisions(messages);
+    expect(decisions.length).toBe(1);
+    expect(decisions[0].rationale).toContain("going with");
+  });
+
+  test("detects 'chosen' keyword", () => {
+    const messages: ConversationMessage[] = [
+      { role: "assistant", content: "We have chosen Vitest as our test framework for its speed and TypeScript support." },
+    ];
+    const decisions = extractDecisions(messages);
+    expect(decisions.length).toBe(1);
+    expect(decisions[0].title).toContain("chosen");
+  });
+
+  test("records decisions via client on agent_end", async () => {
+    const { api, handlers } = mockApi();
+    const client = mockClient();
+    autoSessionMap.set("agent:abc:main", "auto-session-1");
+
+    registerAgentEnd(api, baseConfig, client);
+
+    const handler = handlers.get("agent_end")!;
+    await handler({
+      success: true,
+      ctx: { sessionKey: "agent:abc:main" },
+      messages: [
+        { role: "user", content: "What database should we use?" },
+        { role: "assistant", content: "We decided to use PostgreSQL for the database because of its reliability and JSON support." },
+      ],
+    });
+
+    expect(client.recordDecision).toHaveBeenCalledTimes(1);
+    expect(client.recordDecision).toHaveBeenCalledWith(
+      expect.stringContaining("decided"),
+      expect.any(String),
+      undefined,
+      "test-project",
+      ["auto-detected"],
+      undefined,
+      expect.objectContaining({ session_id: "auto-session-1" }),
+    );
+  });
+
+  test("ignores user messages for decision extraction", () => {
+    const messages: ConversationMessage[] = [
+      { role: "user", content: "We decided to use MySQL." },
+    ];
+    const decisions = extractDecisions(messages);
+    expect(decisions.length).toBe(0);
+  });
+
+  test("caps at 5 decisions", () => {
+    const messages: ConversationMessage[] = Array.from({ length: 10 }, (_, i) => ({
+      role: "assistant" as const,
+      content: `We decided to use option ${i} for component ${i}. Going with approach ${i} instead of alternative.`,
+    }));
+    const decisions = extractDecisions(messages);
+    expect(decisions.length).toBeLessThanOrEqual(5);
+  });
+});
+
+// ============================================================================
+// Session summary generation
+// ============================================================================
+
+describe("generateSessionSummary", () => {
+  test("generates summary from last assistant messages", () => {
+    const messages: ConversationMessage[] = [
+      { role: "assistant", content: "First I analyzed the codebase structure and found the issue." },
+      { role: "user", content: "Great" },
+      { role: "assistant", content: "Then I implemented the fix by updating the validation logic." },
+      { role: "assistant", content: "Finally I ran the tests and all 378 pass successfully." },
+    ];
+    const summary = generateSessionSummary(messages);
+    expect(summary).toContain("validation logic");
+    expect(summary).toContain("378 pass");
+  });
+
+  test("returns fallback for empty messages", () => {
+    const summary = generateSessionSummary([]);
+    expect(summary).toBe("Session completed.");
+  });
+
+  test("skips short assistant messages", () => {
+    const messages: ConversationMessage[] = [
+      { role: "assistant", content: "OK" },
+      { role: "assistant", content: "Done" },
+      { role: "assistant", content: "I completed the full implementation of the authentication system with tests." },
+    ];
+    const summary = generateSessionSummary(messages);
+    expect(summary).toContain("authentication system");
+    expect(summary).not.toContain("OK");
+  });
+});

--- a/tests/integration/capture-pipeline.test.ts
+++ b/tests/integration/capture-pipeline.test.ts
@@ -14,7 +14,7 @@ function mockClient(): MemoryRelayClient {
       metadata: {}, entities: [],
       created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
     })),
-    list: vi.fn(), getOrCreateSession: vi.fn(), endSession: vi.fn(),
+    list: vi.fn(), getOrCreateSession: vi.fn(), startSession: vi.fn(), endSession: vi.fn(), getProjectContext: vi.fn(), recordDecision: vi.fn(),
   };
 }
 

--- a/tests/integration/recall-pipeline.test.ts
+++ b/tests/integration/recall-pipeline.test.ts
@@ -12,7 +12,7 @@ function mockClient(longTermResults: any[] = [], sessionResults: any[] = []): Me
       if (opts?.scope === "session") return sessionResults;
       return [];
     }),
-    store: vi.fn(), list: vi.fn(), getOrCreateSession: vi.fn(), endSession: vi.fn(),
+    store: vi.fn(), list: vi.fn(), getOrCreateSession: vi.fn(), startSession: vi.fn(), endSession: vi.fn(), getProjectContext: vi.fn(), recordDecision: vi.fn(),
   };
 }
 


### PR DESCRIPTION
## Summary

- **Auto session_start**: `before_agent_start` hook calls `session_start()` and stores the session ID for later use
- **Auto project_context**: Loads hot memories, active decisions, and adopted patterns into the prompt at session start
- **Auto decision extraction**: `agent_end` hook detects decisions from conversation using keyword heuristics (`decided`, `going with`, `chosen`, etc.) and records them via `decision_record()`
- **Auto session_end**: Generates a summary from the last significant assistant messages and calls `session_end()` on agent completion
- **Project slug detection**: Resolves from `defaultProject` config → `MEMORYRELAY_DEFAULT_PROJECT` env → working directory name
- **Version bump**: 0.17.2 → 0.18.0 across all 6 locations

All lifecycle operations are non-blocking — failures are logged but never block the turn.

Closes #90

## Test plan

- [x] 21 new tests in `tests/hooks/session-lifecycle.test.ts`
- [x] `session_start` called on `before_agent_start`
- [x] `project_context` called with detected project
- [x] `session_id` stored and retrieved across hooks
- [x] `session_end` called on `agent_end`
- [x] Decision heuristics detect keywords correctly
- [x] Errors caught gracefully (never blocks)
- [x] No `session_end` if no session was started
- [x] All 293 non-cache tests pass (cache tests require better-sqlite3 native dep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)