### PR TITLE
fix: preinstall hook prevents ENOTEMPTY on global upgrade (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.19.5] - 2026-04-05
+
+### Fixed
+- **ENOTEMPTY on global upgrade**: Added `preinstall` script that detects an existing installation and removes it before npm attempts the rename. Prevents `ENOTEMPTY: directory not empty` errors caused by locked native `.node` binaries (better-sqlite3, @matrix-org/...) when running `sudo npm install -g @memoryrelay/plugin-memoryrelay-ai@latest` (#112)
+
 ## [0.19.4] - 2026-04-05
 
 ### Fixed
@@ -384,6 +389,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.12.8]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.12.7...v0.12.8
 [0.12.7]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.12.3...v0.12.7
 [0.12.3]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.12.0...v0.12.3
+[0.19.5]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.19.4...v0.19.5
 [0.19.4]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.19.3...v0.19.4
 [0.19.3]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.19.2...v0.19.3
 [0.19.2]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.19.1...v0.19.2

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 /**
  * OpenClaw Memory Plugin - MemoryRelay
- * Version: 0.19.4
+ * Version: 0.19.5
  *
  * Long-term memory with vector search using MemoryRelay API.
  * Provides auto-recall and auto-capture via lifecycle hooks.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,8 +2,8 @@
   "id": "plugin-memoryrelay-ai",
   "kind": "memory",
   "name": "MemoryRelay AI",
-  "description": "MemoryRelay v0.19.4 - Long-term memory with pipeline architecture, 42 tools, 17 commands, V2 async, sessions, decisions, patterns & projects (api.memoryrelay.net)",
-  "version": "0.19.4",
+  "description": "MemoryRelay v0.19.5 - Long-term memory with pipeline architecture, 42 tools, 17 commands, V2 async, sessions, decisions, patterns & projects (api.memoryrelay.net)",
+  "version": "0.19.5",
   "uiHints": {
     "apiKey": {
       "label": "MemoryRelay API Key",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoryrelay/plugin-memoryrelay-ai",
-  "version": "0.19.4",
+  "version": "0.19.5",
   "description": "OpenClaw memory plugin for MemoryRelay API - 42 tools, 17 commands, V2 async, sessions, decisions, patterns, projects & semantic search",
   "type": "module",
   "main": "index.ts",
@@ -8,7 +8,8 @@
     "postinstall": "node scripts/postinstall.cjs",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "preinstall": "node scripts/preinstall.cjs"
   },
   "keywords": [
     "openclaw",

--- a/scripts/preinstall.cjs
+++ b/scripts/preinstall.cjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Pre-install cleanup for npm global upgrades.
+ *
+ * Problem: npm upgrades rename the existing package dir to a temp location
+ * before extracting the new tarball.  Packages with native .node binaries
+ * (better-sqlite3, @matrix-org/...) leave files that make rmdir fail with
+ * ENOTEMPTY, aborting the entire install.
+ *
+ * Fix: When we detect an existing installation in the global node_modules dir,
+ * remove it before npm tries the rename.  Fresh installs are unaffected because
+ * the target dir won't exist yet.
+ *
+ * Only runs when npm_config_global === "true" (global install) to avoid
+ * interfering with local dev installs.
+ */
+
+const fs   = require('fs');
+const path = require('path');
+
+// Only act on global installs
+if (process.env.npm_config_global !== 'true') process.exit(0);
+
+// The existing install is at the same path npm is about to rename away.
+// npm sets npm_config_prefix (e.g. /usr or /usr/local).
+const prefix    = process.env.npm_config_prefix || '/usr';
+const targetDir = path.join(prefix, 'lib', 'node_modules', '@memoryrelay', 'plugin-memoryrelay-ai');
+
+if (!fs.existsSync(targetDir)) process.exit(0);   // fresh install — nothing to do
+
+try {
+  // Read current version so we can log it
+  let oldVersion = '?';
+  try {
+    const pkg = JSON.parse(fs.readFileSync(path.join(targetDir, 'package.json'), 'utf8'));
+    oldVersion = pkg.version || '?';
+  } catch {}
+
+  fs.rmSync(targetDir, { recursive: true, force: true });
+  console.log(`✅ Removed existing v${oldVersion} install to allow clean upgrade`);
+} catch (err) {
+  // Non-fatal — if we can't remove, npm will fail with ENOTEMPTY as before
+  console.warn('⚠️  Could not remove existing install dir:', err.message);
+  console.warn('   If npm fails with ENOTEMPTY, run manually:');
+  console.warn(`   sudo rm -rf ${targetDir}`);
+}


### PR DESCRIPTION
## Problem

`sudo npm install -g @memoryrelay/plugin-memoryrelay-ai@latest` fails on upgrade with:

```
npm error code ENOTEMPTY  
npm error errno -39
npm error ENOTEMPTY: directory not empty, rename '...plugin-memoryrelay-ai' -> '...-lFLdov5j'
```

npm renames the existing dir to a temp location before extracting the new tarball. `better-sqlite3` and `@matrix-org/matrix-sdk-crypto-nodejs` native binaries leave subdirectories that make the rename fail.

## Fix

New `scripts/preinstall.cjs` hook:

1. Checks `npm_config_global === 'true'` — only acts on global installs
2. Resolves the existing installation path via `npm_config_prefix`
3. If a previous install exists: removes it with `fs.rmSync(..., { recursive: true, force: true })`
4. npm then sees an empty target and the rename succeeds
5. Fresh installs are unaffected (target dir doesn't exist → early exit)

```
✅ Removed existing v0.19.4 install to allow clean upgrade
```

## Tested

- Fresh install: no-ops correctly (dir doesn't exist → exits 0)
- Upgrade scenario: correctly removes old dir → `DIR REMOVED ✅`
- Local dev install (`npm install`, not `-g`): skipped (global flag not set)

Closes #112