### PR TITLE
feat: reduce API call usage (#100)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-04-06
+
+### Changed
+- **autoCapture default is now `off`** (was `conservative`). Users must explicitly opt in to auto-capture by setting `autoCapture: true` or `autoCapture: { tier: "conservative" }` in config. This prevents unintended API quota exhaustion. Closes #100
+
+### Fixed
+- **Recall cooldown**: Skip recall for prompts under 20 chars; enforce 30-second per-session cooldown between recall calls to prevent redundant API calls in rapid exchanges (#100)
+- **Capture cooldown**: Enforce 60-second per-session cooldown between auto-captures — prevents multiple captures per rapid exchange (#100)
+- **Conservative recall defaults**: `recallLimit` default reduced from 5→3, `recallThreshold` raised from 0.3→0.5 for more targeted recall (#100)
+- **Quota warning system**: Before each agent turn (max once per 5 min), checks API quota and warns at 80%+; auto-disables autoCapture at 90%+ to prevent exhaustion (#100)
+
 ## [0.19.10] - 2026-04-06
 
 ### Fixed
@@ -416,6 +427,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.12.8]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.12.7...v0.12.8
 [0.12.7]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.12.3...v0.12.7
 [0.12.3]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.12.0...v0.12.3
+[0.20.0]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.19.10...v0.20.0
 [0.19.10]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.19.9...v0.19.10
 [0.19.9]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.19.8...v0.19.9
 [0.19.8]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.19.7...v0.19.8

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 /**
  * OpenClaw Memory Plugin - MemoryRelay
- * Version: 0.19.10
+ * Version: 0.20.0
  *
  * Long-term memory with vector search using MemoryRelay API.
  * Provides auto-recall and auto-capture via lifecycle hooks.
@@ -125,7 +125,7 @@ function normalizeAutoCaptureConfig(
   config: boolean | AutoCaptureConfig | undefined,
 ): AutoCaptureConfig {
   const defaultConfig: AutoCaptureConfig = {
-    enabled: true,
+    enabled: false,
     tier: "conservative" as AutoCaptureTier,
     confirmFirst: 5,
     categories: {
@@ -657,8 +657,8 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
         agentId: agentId,
         autoRecall: pluginConfig.autoRecall ?? true,
         autoCapture: autoCaptureConfig,
-        recallLimit: pluginConfig.recallLimit ?? 5,
-        recallThreshold: pluginConfig.recallThreshold ?? 0.3,
+        recallLimit: pluginConfig.recallLimit ?? 3,
+        recallThreshold: pluginConfig.recallThreshold ?? 0.5,
         excludeChannels: pluginConfig.excludeChannels ?? [],
         defaultProject,
       };
@@ -943,8 +943,8 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
           agentId,
           autoRecall: pluginConfig.autoRecall ?? true,
           autoCapture: autoCaptureConfig,
-          recallLimit: pluginConfig.recallLimit ?? 5,
-          recallThreshold: pluginConfig.recallThreshold ?? 0.3,
+          recallLimit: pluginConfig.recallLimit ?? 3,
+          recallThreshold: pluginConfig.recallThreshold ?? 0.5,
           excludeChannels: pluginConfig.excludeChannels ?? [],
           defaultProject,
         };
@@ -1196,8 +1196,8 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
         lines.push(`Enabled Tools:       ${cfg?.enabledTools ?? "all"}`);
         lines.push(`Auto-Recall:         ${pluginConfig.autoRecall ?? true}`);
         lines.push(`Auto-Capture:        ${autoCaptureConfig.enabled} (tier: ${autoCaptureConfig.tier})`);
-        lines.push(`Recall Limit:        ${pluginConfig.recallLimit ?? 5}`);
-        lines.push(`Recall Threshold:    ${pluginConfig.recallThreshold ?? 0.3}`);
+        lines.push(`Recall Limit:        ${pluginConfig.recallLimit ?? 3}`);
+        lines.push(`Recall Threshold:    ${pluginConfig.recallThreshold ?? 0.5}`);
         lines.push(`Exclude Channels:    ${(pluginConfig.excludeChannels ?? []).join(", ") || "(none)"}`);
         lines.push(`Session Timeout:     ${cfg?.sessionTimeoutMinutes ?? 120} min`);
         lines.push(`Cleanup Interval:    ${cfg?.sessionCleanupIntervalMinutes ?? 30} min`);

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,8 +2,8 @@
   "id": "plugin-memoryrelay-ai",
   "kind": "memory",
   "name": "MemoryRelay AI",
-  "description": "MemoryRelay v0.19.10 - Long-term memory with pipeline architecture, 42 tools, 17 commands, V2 async, sessions, decisions, patterns & projects (api.memoryrelay.net)",
-  "version": "0.19.10",
+  "description": "MemoryRelay v0.20.0 - Long-term memory with pipeline architecture, 42 tools, 17 commands, V2 async, sessions, decisions, patterns & projects (api.memoryrelay.net)",
+  "version": "0.20.0",
   "uiHints": {
     "apiKey": {
       "label": "MemoryRelay API Key",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,17 @@
 {
   "name": "@memoryrelay/plugin-memoryrelay-ai",
-  "version": "0.18.5",
+  "version": "0.19.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@memoryrelay/plugin-memoryrelay-ai",
-      "version": "0.18.5",
+      "version": "0.19.9",
       "bundleDependencies": [
         "better-sqlite3"
       ],
       "hasInstallScript": true,
       "license": "MIT",
-      "dependencies": {
-        "better-sqlite3": "^12.8.0"
-      },
       "devDependencies": {
         "@types/better-sqlite3": "^7.6.13",
         "@types/node": "^25.3.5",
@@ -26,15 +23,22 @@
         "node": ">=20.0.0"
       },
       "optionalDependencies": {
+        "better-sqlite3": "^12.8.0",
         "sqlite-vec": "^0.1.0"
       },
       "peerDependencies": {
         "openclaw": ">=2026.2.0"
+      },
+      "peerDependenciesMeta": {
+        "openclaw": {
+          "optional": true
+        }
       }
     },
     "node_modules/@agentclientprotocol/sdk": {
       "version": "0.14.1",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
@@ -55,6 +59,7 @@
     "node_modules/@anthropic-ai/sdk": {
       "version": "0.73.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "json-schema-to-ts": "^3.1.1"
@@ -74,6 +79,7 @@
     "node_modules/@aws-crypto/crc32": {
       "version": "5.2.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -87,6 +93,7 @@
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "5.2.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
@@ -101,6 +108,7 @@
     "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
       "version": "2.2.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -112,6 +120,7 @@
     "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
       "version": "2.2.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -124,6 +133,7 @@
     "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
       "version": "2.3.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -136,6 +146,7 @@
     "node_modules/@aws-crypto/sha256-js": {
       "version": "5.2.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-crypto/util": "^5.2.0",
@@ -149,6 +160,7 @@
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "5.2.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -157,6 +169,7 @@
     "node_modules/@aws-crypto/util": {
       "version": "5.2.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
@@ -167,6 +180,7 @@
     "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
       "version": "2.2.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -178,6 +192,7 @@
     "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
       "version": "2.2.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^2.2.0",
@@ -190,6 +205,7 @@
     "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
       "version": "2.3.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^2.2.0",
@@ -202,6 +218,7 @@
     "node_modules/@aws-sdk/client-bedrock": {
       "version": "3.1003.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -252,6 +269,7 @@
     "node_modules/@aws-sdk/client-bedrock-runtime": {
       "version": "3.1003.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -309,6 +327,7 @@
     "node_modules/@aws-sdk/core": {
       "version": "3.973.18",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.5",
@@ -332,6 +351,7 @@
     "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.972.16",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.18",
@@ -347,6 +367,7 @@
     "node_modules/@aws-sdk/credential-provider-http": {
       "version": "3.972.18",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.18",
@@ -367,6 +388,7 @@
     "node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.972.16",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.18",
@@ -391,6 +413,7 @@
     "node_modules/@aws-sdk/credential-provider-login": {
       "version": "3.972.16",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.18",
@@ -409,6 +432,7 @@
     "node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.972.17",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/credential-provider-env": "^3.972.16",
@@ -431,6 +455,7 @@
     "node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.972.16",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.18",
@@ -447,6 +472,7 @@
     "node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.972.16",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.18",
@@ -465,6 +491,7 @@
     "node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.972.16",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.18",
@@ -482,6 +509,7 @@
     "node_modules/@aws-sdk/eventstream-handler-node": {
       "version": "3.972.10",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.5",
@@ -496,6 +524,7 @@
     "node_modules/@aws-sdk/middleware-eventstream": {
       "version": "3.972.7",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.5",
@@ -510,6 +539,7 @@
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.972.7",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.5",
@@ -524,6 +554,7 @@
     "node_modules/@aws-sdk/middleware-logger": {
       "version": "3.972.7",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.5",
@@ -537,6 +568,7 @@
     "node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.972.7",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.5",
@@ -552,6 +584,7 @@
     "node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.972.18",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.18",
@@ -569,6 +602,7 @@
     "node_modules/@aws-sdk/middleware-websocket": {
       "version": "3.972.12",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.5",
@@ -591,6 +625,7 @@
     "node_modules/@aws-sdk/nested-clients": {
       "version": "3.996.6",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -639,6 +674,7 @@
     "node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.972.7",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.5",
@@ -654,6 +690,7 @@
     "node_modules/@aws-sdk/token-providers": {
       "version": "3.1003.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/core": "^3.973.18",
@@ -671,6 +708,7 @@
     "node_modules/@aws-sdk/types": {
       "version": "3.973.5",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -683,6 +721,7 @@
     "node_modules/@aws-sdk/util-endpoints": {
       "version": "3.996.4",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.5",
@@ -698,6 +737,7 @@
     "node_modules/@aws-sdk/util-format-url": {
       "version": "3.972.7",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.5",
@@ -712,6 +752,7 @@
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.965.5",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -723,6 +764,7 @@
     "node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.972.7",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/types": "^3.973.5",
@@ -734,6 +776,7 @@
     "node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.973.3",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-sdk/middleware-user-agent": "^3.972.18",
@@ -757,6 +800,7 @@
     "node_modules/@aws-sdk/xml-builder": {
       "version": "3.972.10",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -770,6 +814,7 @@
     "node_modules/@aws/lambda-invoke-store": {
       "version": "0.2.3",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18.0.0"
@@ -808,6 +853,7 @@
     "node_modules/@babel/runtime": {
       "version": "7.28.6",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=6.9.0"
@@ -833,6 +879,7 @@
     "node_modules/@borewit/text-codec": {
       "version": "0.2.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "funding": {
         "type": "github",
@@ -842,6 +889,7 @@
     "node_modules/@buape/carbon": {
       "version": "0.0.0-beta-20260216184201",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/node": "^25.0.9",
@@ -859,6 +907,7 @@
     "node_modules/@buape/carbon/node_modules/discord-api-types": {
       "version": "0.38.37",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "workspaces": [
         "scripts/actions/documentation"
@@ -867,6 +916,7 @@
     "node_modules/@cacheable/memory": {
       "version": "2.0.8",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@cacheable/utils": "^2.4.0",
@@ -878,6 +928,7 @@
     "node_modules/@cacheable/node-cache": {
       "version": "1.7.6",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "cacheable": "^2.3.1",
@@ -891,6 +942,7 @@
     "node_modules/@cacheable/utils": {
       "version": "2.4.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "hashery": "^1.5.0",
@@ -900,6 +952,7 @@
     "node_modules/@clack/core": {
       "version": "1.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "sisteransi": "^1.0.5"
@@ -908,6 +961,7 @@
     "node_modules/@clack/prompts": {
       "version": "1.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@clack/core": "1.1.0",
@@ -1072,6 +1126,7 @@
     "node_modules/@discordjs/voice": {
       "version": "0.19.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/ws": "^8.18.1",
@@ -1098,6 +1153,7 @@
     "node_modules/@discordjs/voice/node_modules/prism-media": {
       "version": "1.3.5",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "peerDependencies": {
         "@discordjs/opus": ">=0.8.0 <1.0.0",
@@ -1166,6 +1222,7 @@
     "node_modules/@google/genai": {
       "version": "1.44.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "google-auth-library": "^10.3.0",
@@ -1188,6 +1245,7 @@
     "node_modules/@grammyjs/runner": {
       "version": "2.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "abort-controller": "^3.0.0"
@@ -1202,6 +1260,7 @@
     "node_modules/@grammyjs/transformer-throttler": {
       "version": "1.2.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "bottleneck": "^2.0.0"
@@ -1216,11 +1275,13 @@
     "node_modules/@grammyjs/types": {
       "version": "3.25.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@hapi/boom": {
       "version": "9.1.4",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@hapi/hoek": "9.x.x"
@@ -1229,11 +1290,13 @@
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@homebridge/ciao": {
       "version": "1.3.5",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
@@ -1260,6 +1323,7 @@
     "node_modules/@huggingface/jinja": {
       "version": "0.5.5",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -1268,6 +1332,7 @@
     "node_modules/@img/colour": {
       "version": "1.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -1312,6 +1377,7 @@
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "string-width": "^5.1.2",
@@ -1328,11 +1394,13 @@
     "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "eastasianwidth": "^0.2.0",
@@ -1349,6 +1417,7 @@
     "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
       "version": "8.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-styles": "^6.1.0",
@@ -1365,6 +1434,7 @@
     "node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "minipass": "^7.0.4"
@@ -1431,6 +1501,7 @@
     "node_modules/@keyv/bigmap": {
       "version": "1.3.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "hashery": "^1.4.0",
@@ -1446,11 +1517,13 @@
     "node_modules/@keyv/serialize": {
       "version": "1.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@kwsites/file-exists": {
       "version": "1.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "debug": "^4.1.1"
@@ -1459,11 +1532,13 @@
     "node_modules/@kwsites/promise-deferred": {
       "version": "1.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@larksuiteoapi/node-sdk": {
       "version": "1.59.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "axios": "~1.13.3",
@@ -1478,6 +1553,7 @@
     "node_modules/@line/bot-sdk": {
       "version": "10.6.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/node": "^24.0.0"
@@ -1492,6 +1568,7 @@
     "node_modules/@line/bot-sdk/node_modules/@types/node": {
       "version": "24.11.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
@@ -1500,11 +1577,13 @@
     "node_modules/@line/bot-sdk/node_modules/undici-types": {
       "version": "7.16.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@lydell/node-pty": {
       "version": "1.2.0-beta.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "optionalDependencies": {
         "@lydell/node-pty-darwin-arm64": "1.2.0-beta.3",
@@ -1786,6 +1865,7 @@
     "node_modules/@mariozechner/jiti": {
       "version": "2.6.5",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "std-env": "^3.10.0",
@@ -1798,6 +1878,7 @@
     "node_modules/@mariozechner/pi-agent-core": {
       "version": "0.55.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@mariozechner/pi-ai": "^0.55.3"
@@ -1809,6 +1890,7 @@
     "node_modules/@mariozechner/pi-ai": {
       "version": "0.55.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@anthropic-ai/sdk": "^0.73.0",
@@ -1835,6 +1917,7 @@
     "node_modules/@mariozechner/pi-coding-agent": {
       "version": "0.55.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@mariozechner/jiti": "^2.6.2",
@@ -1868,6 +1951,7 @@
     "node_modules/@mariozechner/pi-tui": {
       "version": "0.55.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/mime-types": "^2.1.4",
@@ -1883,6 +1967,7 @@
     },
     "node_modules/@mistralai/mistralai": {
       "version": "1.10.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "zod": "^3.20.0",
@@ -1892,6 +1977,7 @@
     "node_modules/@mistralai/mistralai/node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -1900,6 +1986,7 @@
     "node_modules/@mozilla/readability": {
       "version": "0.6.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=14.0.0"
@@ -1908,6 +1995,7 @@
     "node_modules/@napi-rs/canvas": {
       "version": "0.1.96",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "workspaces": [
         "e2e/*"
@@ -2272,6 +2360,7 @@
     "node_modules/@octokit/app": {
       "version": "16.1.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/auth-app": "^8.1.2",
@@ -2289,6 +2378,7 @@
     "node_modules/@octokit/auth-app": {
       "version": "8.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/auth-oauth-app": "^9.0.3",
@@ -2307,6 +2397,7 @@
     "node_modules/@octokit/auth-oauth-app": {
       "version": "9.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/auth-oauth-device": "^8.0.3",
@@ -2322,6 +2413,7 @@
     "node_modules/@octokit/auth-oauth-device": {
       "version": "8.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/oauth-methods": "^6.0.2",
@@ -2336,6 +2428,7 @@
     "node_modules/@octokit/auth-oauth-user": {
       "version": "6.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/auth-oauth-device": "^8.0.3",
@@ -2351,6 +2444,7 @@
     "node_modules/@octokit/auth-token": {
       "version": "6.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 20"
@@ -2359,6 +2453,7 @@
     "node_modules/@octokit/auth-unauthenticated": {
       "version": "7.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/request-error": "^7.0.2",
@@ -2371,6 +2466,7 @@
     "node_modules/@octokit/core": {
       "version": "7.0.6",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
@@ -2388,6 +2484,7 @@
     "node_modules/@octokit/endpoint": {
       "version": "11.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0",
@@ -2400,6 +2497,7 @@
     "node_modules/@octokit/graphql": {
       "version": "9.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/request": "^10.0.6",
@@ -2413,6 +2511,7 @@
     "node_modules/@octokit/oauth-app": {
       "version": "8.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/auth-oauth-app": "^9.0.2",
@@ -2431,6 +2530,7 @@
     "node_modules/@octokit/oauth-authorization-url": {
       "version": "8.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 20"
@@ -2439,6 +2539,7 @@
     "node_modules/@octokit/oauth-methods": {
       "version": "6.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/oauth-authorization-url": "^8.0.0",
@@ -2453,16 +2554,19 @@
     "node_modules/@octokit/openapi-types": {
       "version": "27.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@octokit/openapi-webhooks-types": {
       "version": "12.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@octokit/plugin-paginate-graphql": {
       "version": "6.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 20"
@@ -2474,6 +2578,7 @@
     "node_modules/@octokit/plugin-paginate-rest": {
       "version": "14.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0"
@@ -2488,6 +2593,7 @@
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
       "version": "17.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0"
@@ -2502,6 +2608,7 @@
     "node_modules/@octokit/plugin-retry": {
       "version": "8.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/request-error": "^7.0.2",
@@ -2518,6 +2625,7 @@
     "node_modules/@octokit/plugin-throttling": {
       "version": "11.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0",
@@ -2533,6 +2641,7 @@
     "node_modules/@octokit/request": {
       "version": "10.0.8",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/endpoint": "^11.0.3",
@@ -2549,6 +2658,7 @@
     "node_modules/@octokit/request-error": {
       "version": "7.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/types": "^16.0.0"
@@ -2560,6 +2670,7 @@
     "node_modules/@octokit/types": {
       "version": "16.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/openapi-types": "^27.0.0"
@@ -2568,6 +2679,7 @@
     "node_modules/@octokit/webhooks": {
       "version": "14.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/openapi-webhooks-types": "12.1.0",
@@ -2581,6 +2693,7 @@
     "node_modules/@octokit/webhooks-methods": {
       "version": "6.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 20"
@@ -2589,6 +2702,7 @@
     "node_modules/@pinojs/redact": {
       "version": "0.4.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@pkgjs/parseargs": {
@@ -2603,26 +2717,31 @@
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.4",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.0",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.0",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1",
@@ -2632,26 +2751,31 @@
     "node_modules/@protobufjs/float": {
       "version": "1.0.2",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/inquire": {
       "version": "1.1.0",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.0",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/@reflink/reflink": {
@@ -2822,16 +2946,19 @@
     "node_modules/@silvia-odwyer/photon-node": {
       "version": "0.3.4",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@slack/bolt": {
       "version": "4.6.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@slack/logger": "^4.0.0",
@@ -2856,6 +2983,7 @@
     "node_modules/@slack/logger": {
       "version": "4.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/node": ">=18.0.0"
@@ -2868,6 +2996,7 @@
     "node_modules/@slack/oauth": {
       "version": "3.0.4",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@slack/logger": "^4",
@@ -2884,6 +3013,7 @@
     "node_modules/@slack/socket-mode": {
       "version": "2.0.5",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@slack/logger": "^4",
@@ -2901,6 +3031,7 @@
     "node_modules/@slack/types": {
       "version": "2.20.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 12.13.0",
@@ -2910,6 +3041,7 @@
     "node_modules/@slack/web-api": {
       "version": "7.14.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@slack/logger": "^4.0.0",
@@ -2933,6 +3065,7 @@
     "node_modules/@smithy/abort-controller": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -2945,6 +3078,7 @@
     "node_modules/@smithy/config-resolver": {
       "version": "4.4.10",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.11",
@@ -2961,6 +3095,7 @@
     "node_modules/@smithy/core": {
       "version": "3.23.8",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/middleware-serde": "^4.2.12",
@@ -2981,6 +3116,7 @@
     "node_modules/@smithy/credential-provider-imds": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.11",
@@ -2996,6 +3132,7 @@
     "node_modules/@smithy/eventstream-codec": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
@@ -3010,6 +3147,7 @@
     "node_modules/@smithy/eventstream-serde-browser": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/eventstream-serde-universal": "^4.2.11",
@@ -3023,6 +3161,7 @@
     "node_modules/@smithy/eventstream-serde-config-resolver": {
       "version": "4.3.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -3035,6 +3174,7 @@
     "node_modules/@smithy/eventstream-serde-node": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/eventstream-serde-universal": "^4.2.11",
@@ -3048,6 +3188,7 @@
     "node_modules/@smithy/eventstream-serde-universal": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/eventstream-codec": "^4.2.11",
@@ -3061,6 +3202,7 @@
     "node_modules/@smithy/fetch-http-handler": {
       "version": "5.3.13",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/protocol-http": "^5.3.11",
@@ -3076,6 +3218,7 @@
     "node_modules/@smithy/hash-node": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -3090,6 +3233,7 @@
     "node_modules/@smithy/invalid-dependency": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -3102,6 +3246,7 @@
     "node_modules/@smithy/is-array-buffer": {
       "version": "4.2.2",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3113,6 +3258,7 @@
     "node_modules/@smithy/middleware-content-length": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/protocol-http": "^5.3.11",
@@ -3126,6 +3272,7 @@
     "node_modules/@smithy/middleware-endpoint": {
       "version": "4.4.22",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/core": "^3.23.8",
@@ -3144,6 +3291,7 @@
     "node_modules/@smithy/middleware-retry": {
       "version": "4.4.39",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.11",
@@ -3163,6 +3311,7 @@
     "node_modules/@smithy/middleware-serde": {
       "version": "4.2.12",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/protocol-http": "^5.3.11",
@@ -3176,6 +3325,7 @@
     "node_modules/@smithy/middleware-stack": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -3188,6 +3338,7 @@
     "node_modules/@smithy/node-config-provider": {
       "version": "4.3.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/property-provider": "^4.2.11",
@@ -3202,6 +3353,7 @@
     "node_modules/@smithy/node-http-handler": {
       "version": "4.4.14",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/abort-controller": "^4.2.11",
@@ -3217,6 +3369,7 @@
     "node_modules/@smithy/property-provider": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -3229,6 +3382,7 @@
     "node_modules/@smithy/protocol-http": {
       "version": "5.3.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -3241,6 +3395,7 @@
     "node_modules/@smithy/querystring-builder": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -3254,6 +3409,7 @@
     "node_modules/@smithy/querystring-parser": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -3266,6 +3422,7 @@
     "node_modules/@smithy/service-error-classification": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.0"
@@ -3277,6 +3434,7 @@
     "node_modules/@smithy/shared-ini-file-loader": {
       "version": "4.4.6",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -3289,6 +3447,7 @@
     "node_modules/@smithy/signature-v4": {
       "version": "5.3.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
@@ -3307,6 +3466,7 @@
     "node_modules/@smithy/smithy-client": {
       "version": "4.12.2",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/core": "^3.23.8",
@@ -3324,6 +3484,7 @@
     "node_modules/@smithy/types": {
       "version": "4.13.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3335,6 +3496,7 @@
     "node_modules/@smithy/url-parser": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/querystring-parser": "^4.2.11",
@@ -3348,6 +3510,7 @@
     "node_modules/@smithy/util-base64": {
       "version": "4.3.2",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.2",
@@ -3361,6 +3524,7 @@
     "node_modules/@smithy/util-body-length-browser": {
       "version": "4.2.2",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3372,6 +3536,7 @@
     "node_modules/@smithy/util-body-length-node": {
       "version": "4.2.3",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3383,6 +3548,7 @@
     "node_modules/@smithy/util-buffer-from": {
       "version": "4.2.2",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/is-array-buffer": "^4.2.2",
@@ -3395,6 +3561,7 @@
     "node_modules/@smithy/util-config-provider": {
       "version": "4.2.2",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3406,6 +3573,7 @@
     "node_modules/@smithy/util-defaults-mode-browser": {
       "version": "4.3.38",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/property-provider": "^4.2.11",
@@ -3420,6 +3588,7 @@
     "node_modules/@smithy/util-defaults-mode-node": {
       "version": "4.2.41",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/config-resolver": "^4.4.10",
@@ -3437,6 +3606,7 @@
     "node_modules/@smithy/util-endpoints": {
       "version": "3.3.2",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/node-config-provider": "^4.3.11",
@@ -3450,6 +3620,7 @@
     "node_modules/@smithy/util-hex-encoding": {
       "version": "4.2.2",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3461,6 +3632,7 @@
     "node_modules/@smithy/util-middleware": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/types": "^4.13.0",
@@ -3473,6 +3645,7 @@
     "node_modules/@smithy/util-retry": {
       "version": "4.2.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/service-error-classification": "^4.2.11",
@@ -3486,6 +3659,7 @@
     "node_modules/@smithy/util-stream": {
       "version": "4.5.17",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/fetch-http-handler": "^5.3.13",
@@ -3504,6 +3678,7 @@
     "node_modules/@smithy/util-uri-escape": {
       "version": "4.2.2",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3515,6 +3690,7 @@
     "node_modules/@smithy/util-utf8": {
       "version": "4.2.2",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.2",
@@ -3527,6 +3703,7 @@
     "node_modules/@smithy/uuid": {
       "version": "1.1.2",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.6.2"
@@ -3538,6 +3715,7 @@
     "node_modules/@snazzah/davey": {
       "version": "0.1.10",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 10"
@@ -3801,6 +3979,7 @@
     "node_modules/@tinyhttp/content-disposition": {
       "version": "2.2.4",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=12.17.0"
@@ -3813,6 +3992,7 @@
     "node_modules/@tokenizer/inflate": {
       "version": "0.4.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
@@ -3829,11 +4009,13 @@
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@tybys/wasm-util": {
@@ -3848,6 +4030,7 @@
     "node_modules/@types/aws-lambda": {
       "version": "8.10.161",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@types/better-sqlite3": {
@@ -3863,6 +4046,7 @@
     "node_modules/@types/body-parser": {
       "version": "1.19.6",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/connect": "*",
@@ -3881,6 +4065,7 @@
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/node": "*"
@@ -3894,6 +4079,7 @@
     "node_modules/@types/express": {
       "version": "5.0.6",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
@@ -3904,6 +4090,7 @@
     "node_modules/@types/express-serve-static-core": {
       "version": "5.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/node": "*",
@@ -3915,11 +4102,13 @@
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@types/jsonwebtoken": {
       "version": "9.0.10",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/ms": "*",
@@ -3929,22 +4118,26 @@
     "node_modules/@types/long": {
       "version": "4.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@types/mime-types": {
       "version": "2.1.4",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@types/node": {
       "version": "25.3.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
       "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -3953,21 +4146,25 @@
     "node_modules/@types/qs": {
       "version": "6.14.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@types/range-parser": {
       "version": "1.2.7",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@types/retry": {
       "version": "0.12.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/@types/send": {
       "version": "1.2.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/node": "*"
@@ -3976,6 +4173,7 @@
     "node_modules/@types/serve-static": {
       "version": "2.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/http-errors": "*",
@@ -3985,6 +4183,7 @@
     "node_modules/@types/ws": {
       "version": "8.18.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/node": "*"
@@ -4093,6 +4292,7 @@
       "version": "7.0.0-rc.9",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@cacheable/node-cache": "^1.4.0",
@@ -4130,6 +4330,7 @@
     "node_modules/@whiskeysockets/baileys/node_modules/p-queue": {
       "version": "9.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "eventemitter3": "^5.0.1",
@@ -4145,6 +4346,7 @@
     "node_modules/@whiskeysockets/baileys/node_modules/p-timeout": {
       "version": "7.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=20"
@@ -4162,6 +4364,7 @@
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -4173,6 +4376,7 @@
     "node_modules/accepts": {
       "version": "2.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "mime-types": "^3.0.0",
@@ -4207,6 +4411,7 @@
     "node_modules/agent-base": {
       "version": "7.1.4",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 14"
@@ -4215,6 +4420,7 @@
     "node_modules/ajv": {
       "version": "8.18.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -4230,6 +4436,7 @@
     "node_modules/ajv-formats": {
       "version": "3.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ajv": "^8.0.0"
@@ -4246,6 +4453,7 @@
     "node_modules/ansi-escapes": {
       "version": "6.2.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=14.16"
@@ -4257,6 +4465,7 @@
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -4268,6 +4477,7 @@
     "node_modules/ansi-styles": {
       "version": "6.2.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -4279,6 +4489,7 @@
     "node_modules/any-promise": {
       "version": "1.3.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/aproba": {
@@ -4317,6 +4528,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "license": "Python-2.0",
+      "optional": true,
       "peer": true
     },
     "node_modules/assertion-error": {
@@ -4330,6 +4542,7 @@
     "node_modules/ast-types": {
       "version": "0.13.4",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.0.1"
@@ -4341,6 +4554,7 @@
     "node_modules/async-mutex": {
       "version": "0.5.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -4349,6 +4563,7 @@
     "node_modules/async-retry": {
       "version": "1.3.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "retry": "0.13.1"
@@ -4357,11 +4572,13 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8.0.0"
@@ -4370,6 +4587,7 @@
     "node_modules/axios": {
       "version": "1.13.6",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.11",
@@ -4380,6 +4598,7 @@
     "node_modules/balanced-match": {
       "version": "4.0.4",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4402,11 +4621,13 @@
         }
       ],
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/basic-ftp": {
       "version": "5.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=10.0.0"
@@ -4415,6 +4636,7 @@
     "node_modules/before-after-hook": {
       "version": "4.0.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true
     },
     "node_modules/better-sqlite3": {
@@ -4424,6 +4646,7 @@
       "hasInstallScript": true,
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "prebuild-install": "^7.1.1"
@@ -4435,6 +4658,7 @@
     "node_modules/bignumber.js": {
       "version": "9.3.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": "*"
@@ -4446,6 +4670,7 @@
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -4456,6 +4681,7 @@
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
@@ -4468,6 +4694,7 @@
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -4480,6 +4707,7 @@
     "node_modules/body-parser": {
       "version": "2.2.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "bytes": "^3.1.2",
@@ -4503,21 +4731,25 @@
     "node_modules/boolbase": {
       "version": "1.0.0",
       "license": "ISC",
+      "optional": true,
       "peer": true
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/bowser": {
       "version": "2.14.1",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/brace-expansion": {
       "version": "5.0.4",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4546,6 +4778,7 @@
       ],
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
@@ -4554,6 +4787,7 @@
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": "*"
@@ -4562,11 +4796,13 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/bun-types": {
@@ -4581,6 +4817,7 @@
     "node_modules/bytes": {
       "version": "3.1.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -4597,6 +4834,7 @@
     "node_modules/cacheable": {
       "version": "2.3.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@cacheable/memory": "^2.0.8",
@@ -4609,6 +4847,7 @@
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -4621,6 +4860,7 @@
     "node_modules/call-bound": {
       "version": "1.0.4",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -4653,6 +4893,7 @@
     "node_modules/chalk": {
       "version": "5.6.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": "^12.17.0 || ^14.13 || >=16.0.0"
@@ -4675,11 +4916,13 @@
     "node_modules/chmodrp": {
       "version": "1.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/chokidar": {
       "version": "5.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
@@ -4694,6 +4937,7 @@
     "node_modules/chownr": {
       "version": "3.0.0",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -4708,6 +4952,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -4716,6 +4961,7 @@
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "restore-cursor": "^5.0.0"
@@ -4730,6 +4976,7 @@
     "node_modules/cli-highlight": {
       "version": "2.1.11",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "chalk": "^4.0.0",
@@ -4750,6 +4997,7 @@
     "node_modules/cli-highlight/node_modules/ansi-regex": {
       "version": "5.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -4758,6 +5006,7 @@
     "node_modules/cli-highlight/node_modules/ansi-styles": {
       "version": "4.3.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -4772,6 +5021,7 @@
     "node_modules/cli-highlight/node_modules/chalk": {
       "version": "4.1.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -4787,6 +5037,7 @@
     "node_modules/cli-highlight/node_modules/cliui": {
       "version": "7.0.4",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
@@ -4797,6 +5048,7 @@
     "node_modules/cli-highlight/node_modules/strip-ansi": {
       "version": "6.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4808,6 +5060,7 @@
     "node_modules/cli-highlight/node_modules/yargs": {
       "version": "16.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "cliui": "^7.0.2",
@@ -4825,6 +5078,7 @@
     "node_modules/cli-highlight/node_modules/yargs-parser": {
       "version": "20.2.9",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -4833,6 +5087,7 @@
     "node_modules/cli-spinners": {
       "version": "2.9.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -4844,6 +5099,7 @@
     "node_modules/cliui": {
       "version": "8.0.1",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
@@ -4857,6 +5113,7 @@
     "node_modules/cliui/node_modules/ansi-regex": {
       "version": "5.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -4865,6 +5122,7 @@
     "node_modules/cliui/node_modules/strip-ansi": {
       "version": "6.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4876,6 +5134,7 @@
     "node_modules/cmake-js": {
       "version": "8.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
@@ -4898,6 +5157,7 @@
     "node_modules/color-convert": {
       "version": "2.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
@@ -4909,6 +5169,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/color-support": {
@@ -4923,6 +5184,7 @@
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
@@ -4934,6 +5196,7 @@
     "node_modules/commander": {
       "version": "10.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=14"
@@ -4958,6 +5221,7 @@
     "node_modules/content-disposition": {
       "version": "1.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -4970,6 +5234,7 @@
     "node_modules/content-type": {
       "version": "1.0.5",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.6"
@@ -4978,6 +5243,7 @@
     "node_modules/cookie": {
       "version": "0.7.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.6"
@@ -4986,6 +5252,7 @@
     "node_modules/cookie-signature": {
       "version": "1.2.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=6.6.0"
@@ -4994,6 +5261,7 @@
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/croner": {
@@ -5009,6 +5277,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18.0"
@@ -5016,6 +5285,7 @@
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -5028,10 +5298,12 @@
     },
     "node_modules/cross-spawn/node_modules/isexe": {
       "version": "2.0.0",
+      "devOptional": true,
       "license": "ISC"
     },
     "node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
+      "devOptional": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -5046,6 +5318,7 @@
     "node_modules/css-select": {
       "version": "5.2.2",
       "license": "BSD-2-Clause",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "boolbase": "^1.0.0",
@@ -5061,6 +5334,7 @@
     "node_modules/css-what": {
       "version": "6.2.2",
       "license": "BSD-2-Clause",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 6"
@@ -5072,16 +5346,19 @@
     "node_modules/cssom": {
       "version": "0.5.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/curve25519-js": {
       "version": "0.0.4",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/data-uri-to-buffer": {
       "version": "6.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 14"
@@ -5089,6 +5366,7 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5108,6 +5386,7 @@
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -5133,6 +5412,7 @@
       "version": "0.6.0",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -5140,6 +5420,7 @@
     "node_modules/degenerator": {
       "version": "5.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ast-types": "^0.13.4",
@@ -5153,6 +5434,7 @@
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.4.0"
@@ -5167,6 +5449,7 @@
     "node_modules/depd": {
       "version": "2.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -5176,6 +5459,7 @@
       "version": "2.1.2",
       "inBundle": true,
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -5183,6 +5467,7 @@
     "node_modules/diff": {
       "version": "8.0.3",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.3.1"
@@ -5199,6 +5484,7 @@
     "node_modules/discord-api-types": {
       "version": "0.38.41",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "workspaces": [
         "scripts/actions/documentation"
@@ -5207,6 +5493,7 @@
     "node_modules/dom-serializer": {
       "version": "2.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
@@ -5226,11 +5513,13 @@
         }
       ],
       "license": "BSD-2-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
       "license": "BSD-2-Clause",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "domelementtype": "^2.3.0"
@@ -5245,6 +5534,7 @@
     "node_modules/domutils": {
       "version": "3.2.2",
       "license": "BSD-2-Clause",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "dom-serializer": "^2.0.0",
@@ -5258,6 +5548,7 @@
     "node_modules/dotenv": {
       "version": "17.3.1",
       "license": "BSD-2-Clause",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -5269,6 +5560,7 @@
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -5282,11 +5574,13 @@
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
@@ -5295,16 +5589,19 @@
     "node_modules/ee-first": {
       "version": "1.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -5314,6 +5611,7 @@
       "version": "1.4.5",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -5321,6 +5619,7 @@
     "node_modules/entities": {
       "version": "4.5.0",
       "license": "BSD-2-Clause",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.12"
@@ -5332,6 +5631,7 @@
     "node_modules/env-var": {
       "version": "7.5.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -5340,6 +5640,7 @@
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.4"
@@ -5348,6 +5649,7 @@
     "node_modules/es-errors": {
       "version": "1.3.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.4"
@@ -5356,6 +5658,7 @@
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -5367,6 +5670,7 @@
     "node_modules/es-set-tostringtag": {
       "version": "2.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5792,6 +6096,7 @@
     "node_modules/escalade": {
       "version": "3.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -5800,11 +6105,13 @@
     "node_modules/escape-html": {
       "version": "1.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/escodegen": {
       "version": "2.1.0",
       "license": "BSD-2-Clause",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
@@ -5825,6 +6132,7 @@
     "node_modules/esprima": {
       "version": "4.0.1",
       "license": "BSD-2-Clause",
+      "optional": true,
       "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
@@ -5837,6 +6145,7 @@
     "node_modules/estraverse": {
       "version": "5.3.0",
       "license": "BSD-2-Clause",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=4.0"
@@ -5853,6 +6162,7 @@
     "node_modules/esutils": {
       "version": "2.0.3",
       "license": "BSD-2-Clause",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -5861,6 +6171,7 @@
     "node_modules/etag": {
       "version": "1.8.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.6"
@@ -5869,6 +6180,7 @@
     "node_modules/event-target-shim": {
       "version": "5.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -5877,6 +6189,7 @@
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/execa": {
@@ -5954,6 +6267,7 @@
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "inBundle": true,
       "license": "(MIT OR WTFPL)",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -5961,6 +6275,7 @@
     "node_modules/express": {
       "version": "5.2.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
@@ -6003,11 +6318,13 @@
     "node_modules/extend": {
       "version": "3.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "license": "BSD-2-Clause",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "debug": "^4.1.1",
@@ -6037,11 +6354,13 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/fast-uri": {
@@ -6057,6 +6376,7 @@
         }
       ],
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/fast-xml-builder": {
@@ -6068,6 +6388,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/fast-xml-parser": {
@@ -6079,6 +6400,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "fast-xml-builder": "^1.0.0",
@@ -6091,6 +6413,7 @@
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "pend": "~1.2.0"
@@ -6109,6 +6432,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "node-domexception": "^1.0.0",
@@ -6121,6 +6445,7 @@
     "node_modules/file-type": {
       "version": "21.3.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@tokenizer/inflate": "^0.4.1",
@@ -6140,11 +6465,13 @@
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/filename-reserved-regex": {
       "version": "3.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
@@ -6156,6 +6483,7 @@
     "node_modules/filenamify": {
       "version": "6.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "filename-reserved-regex": "^3.0.0"
@@ -6170,6 +6498,7 @@
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
@@ -6196,6 +6525,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=4.0"
@@ -6209,6 +6539,7 @@
     "node_modules/foreground-child": {
       "version": "3.3.1",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "cross-spawn": "^7.0.6",
@@ -6224,6 +6555,7 @@
     "node_modules/foreground-child/node_modules/signal-exit": {
       "version": "4.1.0",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=14"
@@ -6235,6 +6567,7 @@
     "node_modules/form-data": {
       "version": "4.0.5",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -6250,6 +6583,7 @@
     "node_modules/form-data/node_modules/mime-db": {
       "version": "1.52.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.6"
@@ -6258,6 +6592,7 @@
     "node_modules/form-data/node_modules/mime-types": {
       "version": "2.1.35",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
@@ -6269,6 +6604,7 @@
     "node_modules/formdata-polyfill": {
       "version": "4.0.10",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "fetch-blob": "^3.1.2"
@@ -6280,6 +6616,7 @@
     "node_modules/forwarded": {
       "version": "0.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.6"
@@ -6288,6 +6625,7 @@
     "node_modules/fresh": {
       "version": "2.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -6298,11 +6636,13 @@
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fs-extra": {
       "version": "11.3.4",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -6351,6 +6691,7 @@
     "node_modules/function-bind": {
       "version": "1.1.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6400,6 +6741,7 @@
     "node_modules/gaxios": {
       "version": "7.1.3",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
@@ -6414,11 +6756,13 @@
     "node_modules/gaxios/node_modules/balanced-match": {
       "version": "1.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/gaxios/node_modules/brace-expansion": {
       "version": "2.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6427,6 +6771,7 @@
     "node_modules/gaxios/node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 12"
@@ -6435,6 +6780,7 @@
     "node_modules/gaxios/node_modules/glob": {
       "version": "10.5.0",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "foreground-child": "^3.1.0",
@@ -6454,11 +6800,13 @@
     "node_modules/gaxios/node_modules/lru-cache": {
       "version": "10.4.3",
       "license": "ISC",
+      "optional": true,
       "peer": true
     },
     "node_modules/gaxios/node_modules/minimatch": {
       "version": "9.0.9",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "brace-expansion": "^2.0.2"
@@ -6473,6 +6821,7 @@
     "node_modules/gaxios/node_modules/node-fetch": {
       "version": "3.3.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
@@ -6490,6 +6839,7 @@
     "node_modules/gaxios/node_modules/path-scurry": {
       "version": "1.11.1",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "lru-cache": "^10.2.0",
@@ -6505,6 +6855,7 @@
     "node_modules/gaxios/node_modules/rimraf": {
       "version": "5.0.10",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "glob": "^10.3.7"
@@ -6519,6 +6870,7 @@
     "node_modules/gcp-metadata": {
       "version": "8.1.2",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "gaxios": "^7.0.0",
@@ -6532,6 +6884,7 @@
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
@@ -6540,6 +6893,7 @@
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -6559,6 +6913,7 @@
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -6582,6 +6937,7 @@
     "node_modules/get-proto": {
       "version": "1.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -6594,6 +6950,7 @@
     "node_modules/get-stream": {
       "version": "5.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
@@ -6608,6 +6965,7 @@
     "node_modules/get-uri": {
       "version": "6.0.5",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "basic-ftp": "^5.0.2",
@@ -6623,11 +6981,13 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/glob": {
       "version": "13.0.6",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "minimatch": "^10.2.2",
@@ -6644,6 +7004,7 @@
     "node_modules/google-auth-library": {
       "version": "10.6.1",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
@@ -6660,6 +7021,7 @@
     "node_modules/google-logging-utils": {
       "version": "1.1.3",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=14"
@@ -6668,6 +7030,7 @@
     "node_modules/gopd": {
       "version": "1.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.4"
@@ -6679,11 +7042,13 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "license": "ISC",
+      "optional": true,
       "peer": true
     },
     "node_modules/grammy": {
       "version": "1.41.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@grammyjs/types": "3.25.0",
@@ -6697,6 +7062,7 @@
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6705,6 +7071,7 @@
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.4"
@@ -6716,6 +7083,7 @@
     "node_modules/has-tostringtag": {
       "version": "1.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -6736,6 +7104,7 @@
     "node_modules/hashery": {
       "version": "1.5.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "hookified": "^1.14.0"
@@ -6747,6 +7116,7 @@
     "node_modules/hasown": {
       "version": "2.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -6758,6 +7128,7 @@
     "node_modules/highlight.js": {
       "version": "10.7.3",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": "*"
@@ -6775,11 +7146,13 @@
     "node_modules/hookified": {
       "version": "1.15.1",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/hosted-git-info": {
       "version": "9.0.2",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "lru-cache": "^11.1.0"
@@ -6803,6 +7176,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "domelementtype": "^2.3.0",
@@ -6814,6 +7188,7 @@
     "node_modules/htmlparser2/node_modules/entities": {
       "version": "7.0.1",
       "license": "BSD-2-Clause",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.12"
@@ -6825,6 +7200,7 @@
     "node_modules/http-errors": {
       "version": "2.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "depd": "~2.0.0",
@@ -6844,6 +7220,7 @@
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -6856,6 +7233,7 @@
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -6876,6 +7254,7 @@
     "node_modules/iconv-lite": {
       "version": "0.7.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -6905,11 +7284,13 @@
         }
       ],
       "inBundle": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/ignore": {
       "version": "7.0.5",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 4"
@@ -6918,6 +7299,7 @@
     "node_modules/immediate": {
       "version": "3.0.6",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/inflight": {
@@ -6931,17 +7313,20 @@
     },
     "node_modules/inherits": {
       "version": "2.0.4",
+      "devOptional": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 12"
@@ -6950,6 +7335,7 @@
     "node_modules/ipaddr.js": {
       "version": "2.3.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 10"
@@ -6958,6 +7344,7 @@
     "node_modules/ipull": {
       "version": "3.9.5",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@tinyhttp/content-disposition": "^2.2.0",
@@ -6997,11 +7384,13 @@
     "node_modules/ipull/node_modules/lifecycle-utils": {
       "version": "2.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/ipull/node_modules/parse-ms": {
       "version": "3.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -7013,6 +7402,7 @@
     "node_modules/ipull/node_modules/pretty-ms": {
       "version": "8.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "parse-ms": "^3.0.0"
@@ -7027,6 +7417,7 @@
     "node_modules/ipull/node_modules/slice-ansi": {
       "version": "7.1.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-styles": "^6.2.1",
@@ -7042,11 +7433,13 @@
     "node_modules/is-electron": {
       "version": "2.2.2",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "5.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "get-east-asian-width": "^1.3.1"
@@ -7061,6 +7454,7 @@
     "node_modules/is-interactive": {
       "version": "2.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -7072,11 +7466,13 @@
     "node_modules/is-promise": {
       "version": "4.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -7088,6 +7484,7 @@
     "node_modules/is-unicode-supported": {
       "version": "2.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -7099,11 +7496,13 @@
     "node_modules/isarray": {
       "version": "1.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/isexe": {
       "version": "4.0.0",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=20"
@@ -7158,6 +7557,7 @@
     "node_modules/jackspeak": {
       "version": "3.4.3",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@isaacs/cliui": "^8.0.2"
@@ -7172,6 +7572,7 @@
     "node_modules/jiti": {
       "version": "2.6.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -7185,6 +7586,7 @@
     "node_modules/json-bigint": {
       "version": "1.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
@@ -7193,6 +7595,7 @@
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
@@ -7205,16 +7608,19 @@
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/json-with-bigint": {
       "version": "3.5.7",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "bin": {
         "json5": "lib/cli.js"
@@ -7226,6 +7632,7 @@
     "node_modules/jsonfile": {
       "version": "6.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "universalify": "^2.0.0"
@@ -7237,6 +7644,7 @@
     "node_modules/jsonwebtoken": {
       "version": "9.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "jws": "^4.0.1",
@@ -7258,6 +7666,7 @@
     "node_modules/jszip": {
       "version": "3.10.1",
       "license": "(MIT OR GPL-3.0-or-later)",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "lie": "~3.3.0",
@@ -7269,6 +7678,7 @@
     "node_modules/jwa": {
       "version": "2.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
@@ -7279,6 +7689,7 @@
     "node_modules/jws": {
       "version": "4.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "jwa": "^2.0.1",
@@ -7288,6 +7699,7 @@
     "node_modules/keyv": {
       "version": "5.6.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
@@ -7297,6 +7709,7 @@
       "version": "2.15.1",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "funding": {
         "url": "https://liberapay.com/Koromix"
@@ -7307,6 +7720,7 @@
       "version": "2.0.1",
       "resolved": "git+ssh://git@github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67",
       "license": "GPL-3.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "curve25519-js": "^0.0.4",
@@ -7316,17 +7730,20 @@
     "node_modules/libsignal/node_modules/@types/node": {
       "version": "10.17.60",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/libsignal/node_modules/long": {
       "version": "4.0.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true
     },
     "node_modules/libsignal/node_modules/protobufjs": {
       "version": "6.8.8",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -7351,6 +7768,7 @@
     "node_modules/lie": {
       "version": "3.3.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "immediate": "~3.0.5"
@@ -7359,11 +7777,13 @@
     "node_modules/lifecycle-utils": {
       "version": "3.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/linkedom": {
       "version": "0.18.12",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "css-select": "^5.1.0",
@@ -7387,11 +7807,13 @@
     "node_modules/linkedom/node_modules/html-escaper": {
       "version": "3.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/linkify-it": {
       "version": "5.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "uc.micro": "^2.0.0"
@@ -7415,61 +7837,73 @@
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/lodash.identity": {
       "version": "3.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/lodash.pickby": {
       "version": "4.6.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/log-symbols": {
       "version": "7.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "is-unicode-supported": "^2.0.0",
@@ -7485,6 +7919,7 @@
     "node_modules/long": {
       "version": "5.3.2",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true
     },
     "node_modules/loupe": {
@@ -7498,6 +7933,7 @@
     "node_modules/lowdb": {
       "version": "7.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "steno": "^4.0.2"
@@ -7512,6 +7948,7 @@
     "node_modules/lru-cache": {
       "version": "11.2.6",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": "20 || >=22"
@@ -7552,6 +7989,7 @@
     "node_modules/markdown-it": {
       "version": "14.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
@@ -7568,6 +8006,7 @@
     "node_modules/marked": {
       "version": "15.0.12",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "bin": {
         "marked": "bin/marked.js"
@@ -7579,6 +8018,7 @@
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.4"
@@ -7587,11 +8027,13 @@
     "node_modules/mdurl": {
       "version": "2.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -7600,6 +8042,7 @@
     "node_modules/merge-descriptors": {
       "version": "2.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -7616,6 +8059,7 @@
     "node_modules/mime-db": {
       "version": "1.54.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.6"
@@ -7624,6 +8068,7 @@
     "node_modules/mime-types": {
       "version": "3.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "mime-db": "^1.54.0"
@@ -7650,6 +8095,7 @@
     "node_modules/mimic-function": {
       "version": "5.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -7664,6 +8110,7 @@
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -7674,6 +8121,7 @@
     "node_modules/minimatch": {
       "version": "10.2.4",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "brace-expansion": "^5.0.2"
@@ -7689,6 +8137,7 @@
       "version": "1.2.8",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -7696,6 +8145,7 @@
     "node_modules/minipass": {
       "version": "7.1.3",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
@@ -7704,6 +8154,7 @@
     "node_modules/minizlib": {
       "version": "3.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "minipass": "^7.1.2"
@@ -7729,7 +8180,8 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/mlly": {
       "version": "1.8.1",
@@ -7749,6 +8201,7 @@
     },
     "node_modules/ms": {
       "version": "2.1.3",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/music-metadata": {
@@ -7764,6 +8217,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@borewit/text-codec": "^0.2.1",
@@ -7784,6 +8238,7 @@
     "node_modules/mz": {
       "version": "2.7.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -7800,6 +8255,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "bin": {
         "nanoid": "bin/nanoid.js"
@@ -7813,11 +8269,13 @@
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.6"
@@ -7826,6 +8284,7 @@
     "node_modules/netmask": {
       "version": "2.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.4.0"
@@ -7837,6 +8296,7 @@
       "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -7847,6 +8307,7 @@
     "node_modules/node-addon-api": {
       "version": "8.6.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": "^18 || ^20 || >= 21"
@@ -7855,12 +8316,14 @@
     "node_modules/node-api-headers": {
       "version": "1.8.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/node-domexception": {
       "name": "@nolyfill/domexception",
       "version": "1.0.28",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=12.4.0"
@@ -7869,6 +8332,7 @@
     "node_modules/node-edge-tts": {
       "version": "1.2.10",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "https-proxy-agent": "^7.0.1",
@@ -7882,6 +8346,7 @@
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -7902,6 +8367,7 @@
       "version": "3.16.2",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@huggingface/jinja": "^0.5.5",
@@ -8151,6 +8617,7 @@
     "node_modules/nth-check": {
       "version": "2.1.1",
       "license": "BSD-2-Clause",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "boolbase": "^1.0.0"
@@ -8162,6 +8629,7 @@
     "node_modules/object-assign": {
       "version": "4.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -8170,6 +8638,7 @@
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.4"
@@ -8181,6 +8650,7 @@
     "node_modules/octokit": {
       "version": "5.0.5",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@octokit/app": "^16.1.2",
@@ -8202,6 +8672,7 @@
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=14.0.0"
@@ -8210,6 +8681,7 @@
     "node_modules/on-finished": {
       "version": "2.4.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ee-first": "1.1.1"
@@ -8220,6 +8692,7 @@
     },
     "node_modules/once": {
       "version": "1.4.0",
+      "devOptional": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -8229,6 +8702,7 @@
     "node_modules/onetime": {
       "version": "7.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "mimic-function": "^5.0.0"
@@ -8243,6 +8717,7 @@
     "node_modules/openai": {
       "version": "6.10.0",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "bin": {
         "openai": "bin/cli"
@@ -8263,6 +8738,7 @@
     "node_modules/openclaw": {
       "version": "2026.3.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@agentclientprotocol/sdk": "0.14.1",
@@ -8341,6 +8817,7 @@
     "node_modules/openclaw/node_modules/commander": {
       "version": "14.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=20"
@@ -8351,6 +8828,7 @@
       "resolved": "https://registry.npmjs.org/sqlite-vec/-/sqlite-vec-0.1.7-alpha.2.tgz",
       "integrity": "sha512-rNgRCv+4V4Ed3yc33Qr+nNmjhtrMnnHzXfLVPeGb28Dx5mmDL3Ngw/Wk8vhCGjj76+oC6gnkmMG8y73BZWGBwQ==",
       "license": "MIT OR Apache",
+      "optional": true,
       "peer": true,
       "optionalDependencies": {
         "sqlite-vec-darwin-arm64": "0.1.7-alpha.2",
@@ -8433,6 +8911,7 @@
     "node_modules/openclaw/node_modules/tar": {
       "version": "7.5.9",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -8448,11 +8927,13 @@
     "node_modules/opusscript": {
       "version": "0.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/ora": {
       "version": "9.3.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "chalk": "^5.6.2",
@@ -8474,6 +8955,7 @@
     "node_modules/ora/node_modules/cli-spinners": {
       "version": "3.4.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18.20"
@@ -8485,6 +8967,7 @@
     "node_modules/ora/node_modules/string-width": {
       "version": "8.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "get-east-asian-width": "^1.5.0",
@@ -8500,6 +8983,7 @@
     "node_modules/osc-progress": {
       "version": "0.3.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=20"
@@ -8508,6 +8992,7 @@
     "node_modules/p-finally": {
       "version": "1.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=4"
@@ -8530,6 +9015,7 @@
     "node_modules/p-queue": {
       "version": "6.6.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "eventemitter3": "^4.0.4",
@@ -8545,11 +9031,13 @@
     "node_modules/p-queue/node_modules/eventemitter3": {
       "version": "4.0.7",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/p-retry": {
       "version": "4.6.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@types/retry": "0.12.0",
@@ -8562,6 +9050,7 @@
     "node_modules/p-timeout": {
       "version": "3.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "p-finally": "^1.0.0"
@@ -8573,6 +9062,7 @@
     "node_modules/pac-proxy-agent": {
       "version": "7.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
@@ -8591,6 +9081,7 @@
     "node_modules/pac-resolver": {
       "version": "7.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "degenerator": "^5.0.0",
@@ -8603,16 +9094,19 @@
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "peer": true
     },
     "node_modules/pako": {
       "version": "1.0.11",
       "license": "(MIT AND Zlib)",
+      "optional": true,
       "peer": true
     },
     "node_modules/parse-ms": {
       "version": "4.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -8624,11 +9118,13 @@
     "node_modules/parse5": {
       "version": "5.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/parse5-htmlparser2-tree-adapter": {
       "version": "6.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "parse5": "^6.0.1"
@@ -8637,11 +9133,13 @@
     "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
       "version": "6.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -8650,6 +9148,7 @@
     "node_modules/partial-json": {
       "version": "0.1.7",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/path-is-absolute": {
@@ -8662,6 +9161,7 @@
     },
     "node_modules/path-key": {
       "version": "3.1.1",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -8670,6 +9170,7 @@
     "node_modules/path-scurry": {
       "version": "2.0.2",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "lru-cache": "^11.0.0",
@@ -8685,6 +9186,7 @@
     "node_modules/path-to-regexp": {
       "version": "8.3.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "funding": {
         "type": "opencollective",
@@ -8707,6 +9209,7 @@
     "node_modules/pdfjs-dist": {
       "version": "5.5.207",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=20.19.0 || >=22.13.0 || >=24"
@@ -8719,6 +9222,7 @@
     "node_modules/pend": {
       "version": "1.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/picocolors": {
@@ -8729,6 +9233,7 @@
     "node_modules/pino": {
       "version": "9.14.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
@@ -8750,6 +9255,7 @@
     "node_modules/pino-abstract-transport": {
       "version": "2.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "split2": "^4.0.0"
@@ -8758,6 +9264,7 @@
     "node_modules/pino-std-serializers": {
       "version": "7.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/pkg-types": {
@@ -8778,6 +9285,7 @@
     "node_modules/playwright-core": {
       "version": "1.58.2",
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "bin": {
         "playwright-core": "cli.js"
@@ -8837,6 +9345,7 @@
       "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -8861,6 +9370,7 @@
     "node_modules/pretty-bytes": {
       "version": "6.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": "^14.13.1 || >=16.0.0"
@@ -8896,6 +9406,7 @@
     "node_modules/pretty-ms": {
       "version": "9.3.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "parse-ms": "^4.0.0"
@@ -8910,6 +9421,7 @@
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/process-warning": {
@@ -8925,11 +9437,13 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/proper-lockfile": {
       "version": "4.1.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.4",
@@ -8940,6 +9454,7 @@
     "node_modules/proper-lockfile/node_modules/retry": {
       "version": "0.12.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 4"
@@ -8949,6 +9464,7 @@
       "version": "7.5.4",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
@@ -8971,6 +9487,7 @@
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "forwarded": "0.2.0",
@@ -8983,6 +9500,7 @@
     "node_modules/proxy-addr/node_modules/ipaddr.js": {
       "version": "1.9.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.10"
@@ -8991,6 +9509,7 @@
     "node_modules/proxy-agent": {
       "version": "6.5.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -9009,6 +9528,7 @@
     "node_modules/proxy-agent/node_modules/lru-cache": {
       "version": "7.18.3",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -9017,12 +9537,14 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/pump": {
       "version": "3.0.4",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -9031,6 +9553,7 @@
     "node_modules/punycode.js": {
       "version": "2.3.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=6"
@@ -9039,6 +9562,7 @@
     "node_modules/qified": {
       "version": "0.6.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "hookified": "^1.14.0"
@@ -9049,6 +9573,7 @@
     },
     "node_modules/qrcode-terminal": {
       "version": "0.12.0",
+      "optional": true,
       "peer": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -9057,6 +9582,7 @@
     "node_modules/qs": {
       "version": "6.15.0",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -9071,11 +9597,13 @@
     "node_modules/quick-format-unescaped": {
       "version": "4.0.4",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.6"
@@ -9084,6 +9612,7 @@
     "node_modules/raw-body": {
       "version": "3.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "bytes": "~3.1.2",
@@ -9099,6 +9628,7 @@
       "version": "1.2.8",
       "inBundle": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -9117,6 +9647,7 @@
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
@@ -9131,11 +9662,13 @@
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/readdirp": {
       "version": "5.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 20.19.0"
@@ -9148,6 +9681,7 @@
     "node_modules/real-require": {
       "version": "0.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 12.13.0"
@@ -9156,6 +9690,7 @@
     "node_modules/require-directory": {
       "version": "2.1.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -9164,6 +9699,7 @@
     "node_modules/require-from-string": {
       "version": "2.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -9172,6 +9708,7 @@
     "node_modules/restore-cursor": {
       "version": "5.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "onetime": "^7.0.0",
@@ -9187,6 +9724,7 @@
     "node_modules/restore-cursor/node_modules/signal-exit": {
       "version": "4.1.0",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=14"
@@ -9198,6 +9736,7 @@
     "node_modules/retry": {
       "version": "0.13.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 4"
@@ -9663,6 +10202,7 @@
     "node_modules/router": {
       "version": "2.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
@@ -9692,11 +10232,13 @@
         }
       ],
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -9705,10 +10247,12 @@
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/semver": {
       "version": "7.7.4",
+      "devOptional": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -9721,6 +10265,7 @@
     "node_modules/send": {
       "version": "1.2.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "debug": "^4.4.3",
@@ -9746,6 +10291,7 @@
     "node_modules/serve-static": {
       "version": "2.2.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "encodeurl": "^2.0.0",
@@ -9770,17 +10316,20 @@
     "node_modules/setimmediate": {
       "version": "1.0.5",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "license": "ISC",
+      "optional": true,
       "peer": true
     },
     "node_modules/sharp": {
       "version": "0.34.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
@@ -10262,6 +10811,7 @@
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -10272,6 +10822,7 @@
     },
     "node_modules/shebang-regex": {
       "version": "3.0.0",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -10280,6 +10831,7 @@
     "node_modules/side-channel": {
       "version": "1.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10298,6 +10850,7 @@
     "node_modules/side-channel-list": {
       "version": "1.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10313,6 +10866,7 @@
     "node_modules/side-channel-map": {
       "version": "1.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -10330,6 +10884,7 @@
     "node_modules/side-channel-weakmap": {
       "version": "1.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -10353,6 +10908,7 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "license": "ISC",
+      "optional": true,
       "peer": true
     },
     "node_modules/simple-concat": {
@@ -10374,7 +10930,8 @@
         }
       ],
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -10396,6 +10953,7 @@
       ],
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -10405,6 +10963,7 @@
     "node_modules/simple-git": {
       "version": "3.32.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@kwsites/file-exists": "^1.1.1",
@@ -10419,16 +10978,19 @@
     "node_modules/sisteransi": {
       "version": "1.0.5",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/sleep-promise": {
       "version": "9.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/slice-ansi": {
       "version": "8.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-styles": "^6.2.3",
@@ -10444,6 +11006,7 @@
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 6.0.0",
@@ -10453,6 +11016,7 @@
     "node_modules/socks": {
       "version": "2.8.7",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ip-address": "^10.0.1",
@@ -10466,6 +11030,7 @@
     "node_modules/socks-proxy-agent": {
       "version": "8.0.5",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -10479,6 +11044,7 @@
     "node_modules/sonic-boom": {
       "version": "4.2.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -10487,6 +11053,7 @@
     "node_modules/source-map": {
       "version": "0.6.1",
       "license": "BSD-3-Clause",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.10.0"
@@ -10503,6 +11070,7 @@
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
@@ -10512,6 +11080,7 @@
     "node_modules/split2": {
       "version": "4.2.0",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 10.x"
@@ -10604,6 +11173,7 @@
     "node_modules/statuses": {
       "version": "2.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -10611,11 +11181,13 @@
     },
     "node_modules/std-env": {
       "version": "3.10.0",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.3.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -10627,6 +11199,7 @@
     "node_modules/stdout-update": {
       "version": "4.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-escapes": "^6.2.0",
@@ -10641,11 +11214,13 @@
     "node_modules/stdout-update/node_modules/emoji-regex": {
       "version": "10.6.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/stdout-update/node_modules/string-width": {
       "version": "7.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "emoji-regex": "^10.3.0",
@@ -10662,6 +11237,7 @@
     "node_modules/steno": {
       "version": "4.0.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -10674,6 +11250,7 @@
       "version": "1.1.1",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -10681,11 +11258,13 @@
     "node_modules/string_decoder/node_modules/safe-buffer": {
       "version": "5.1.2",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/string-width": {
       "version": "4.2.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -10700,6 +11279,7 @@
       "name": "string-width",
       "version": "4.2.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
@@ -10713,6 +11293,7 @@
     "node_modules/string-width-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -10721,6 +11302,7 @@
     "node_modules/string-width-cjs/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -10729,6 +11311,7 @@
     "node_modules/string-width-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -10740,6 +11323,7 @@
     "node_modules/string-width/node_modules/ansi-regex": {
       "version": "5.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -10748,6 +11332,7 @@
     "node_modules/string-width/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -10756,6 +11341,7 @@
     "node_modules/string-width/node_modules/strip-ansi": {
       "version": "6.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -10767,6 +11353,7 @@
     "node_modules/strip-ansi": {
       "version": "7.2.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-regex": "^6.2.2"
@@ -10782,6 +11369,7 @@
       "name": "strip-ansi",
       "version": "6.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -10793,6 +11381,7 @@
     "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -10813,6 +11402,7 @@
       "version": "2.0.1",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10837,11 +11427,13 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/strtok3": {
       "version": "10.3.4",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@tokenizer/token": "^0.3.0"
@@ -10856,6 +11448,7 @@
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -10867,6 +11460,7 @@
     "node_modules/tar": {
       "version": "7.5.10",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -10885,6 +11479,7 @@
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -10897,7 +11492,8 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
       "inBundle": true,
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
@@ -10905,6 +11501,7 @@
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -10922,6 +11519,7 @@
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "inBundle": true,
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -10991,6 +11589,7 @@
     "node_modules/thenify": {
       "version": "3.3.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -10999,6 +11598,7 @@
     "node_modules/thenify-all": {
       "version": "1.6.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -11010,6 +11610,7 @@
     "node_modules/thread-stream": {
       "version": "3.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "real-require": "^0.2.0"
@@ -11039,6 +11640,7 @@
     "node_modules/toad-cache": {
       "version": "3.7.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -11047,6 +11649,7 @@
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.6"
@@ -11055,6 +11658,7 @@
     "node_modules/token-types": {
       "version": "6.1.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "@borewit/text-codec": "^0.2.1",
@@ -11072,21 +11676,25 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/tslib": {
       "version": "2.8.1",
       "license": "0BSD",
+      "optional": true,
       "peer": true
     },
     "node_modules/tslog": {
       "version": "4.10.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=16"
@@ -11098,6 +11706,7 @@
     "node_modules/tsscmp": {
       "version": "1.0.6",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=0.6.x"
@@ -11109,6 +11718,7 @@
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "inBundle": true,
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -11127,6 +11737,7 @@
     "node_modules/type-is": {
       "version": "2.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "content-type": "^1.0.5",
@@ -11154,6 +11765,7 @@
     "node_modules/uc.micro": {
       "version": "2.1.0",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/ufo": {
@@ -11164,11 +11776,13 @@
     "node_modules/uhyphen": {
       "version": "0.2.0",
       "license": "ISC",
+      "optional": true,
       "peer": true
     },
     "node_modules/uint8array-extras": {
       "version": "1.5.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -11180,6 +11794,7 @@
     "node_modules/undici": {
       "version": "7.22.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=20.18.1"
@@ -11187,21 +11802,25 @@
     },
     "node_modules/undici-types": {
       "version": "7.18.2",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/universal-github-app-jwt": {
       "version": "2.2.2",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/universal-user-agent": {
       "version": "7.0.3",
       "license": "ISC",
+      "optional": true,
       "peer": true
     },
     "node_modules/universalify": {
       "version": "2.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 10.0.0"
@@ -11210,6 +11829,7 @@
     "node_modules/unpipe": {
       "version": "1.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -11218,16 +11838,19 @@
     "node_modules/url-join": {
       "version": "4.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "inBundle": true,
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/validate-npm-package-name": {
       "version": "7.0.2",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -11236,6 +11859,7 @@
     "node_modules/vary": {
       "version": "1.1.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 0.8"
@@ -11402,6 +12026,7 @@
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">= 8"
@@ -11410,11 +12035,13 @@
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "license": "BSD-2-Clause",
+      "optional": true,
       "peer": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
@@ -11424,6 +12051,7 @@
     "node_modules/which": {
       "version": "6.0.1",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "isexe": "^4.0.0"
@@ -11462,11 +12090,13 @@
     "node_modules/win-guid": {
       "version": "0.2.1",
       "license": "MIT",
+      "optional": true,
       "peer": true
     },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -11484,6 +12114,7 @@
       "name": "wrap-ansi",
       "version": "7.0.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
@@ -11500,6 +12131,7 @@
     "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
       "version": "5.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -11508,6 +12140,7 @@
     "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -11522,6 +12155,7 @@
     "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
       "version": "6.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -11533,6 +12167,7 @@
     "node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "5.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=8"
@@ -11541,6 +12176,7 @@
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -11555,6 +12191,7 @@
     "node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "6.0.1",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -11565,12 +12202,14 @@
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
+      "devOptional": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.19.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=10.0.0"
@@ -11591,6 +12230,7 @@
     "node_modules/y18n": {
       "version": "5.0.8",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=10"
@@ -11599,6 +12239,7 @@
     "node_modules/yallist": {
       "version": "5.0.0",
       "license": "BlueOak-1.0.0",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -11607,6 +12248,7 @@
     "node_modules/yaml": {
       "version": "2.8.2",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "bin": {
         "yaml": "bin.mjs"
@@ -11621,6 +12263,7 @@
     "node_modules/yargs": {
       "version": "17.7.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
@@ -11638,6 +12281,7 @@
     "node_modules/yargs-parser": {
       "version": "21.1.1",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=12"
@@ -11646,6 +12290,7 @@
     "node_modules/yauzl": {
       "version": "2.10.0",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "dependencies": {
         "buffer-crc32": "~0.2.3",
@@ -11666,6 +12311,7 @@
     "node_modules/yoctocolors": {
       "version": "2.1.2",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "engines": {
         "node": ">=18"
@@ -11677,6 +12323,7 @@
     "node_modules/zod": {
       "version": "4.3.6",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -11685,6 +12332,7 @@
     "node_modules/zod-to-json-schema": {
       "version": "3.25.1",
       "license": "ISC",
+      "optional": true,
       "peer": true,
       "peerDependencies": {
         "zod": "^3.25 || ^4"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoryrelay/plugin-memoryrelay-ai",
-  "version": "0.19.10",
+  "version": "0.20.0",
   "description": "OpenClaw memory plugin for MemoryRelay API - 42 tools, 17 commands, V2 async, sessions, decisions, patterns, projects & semantic search",
   "type": "module",
   "main": "index.ts",

--- a/src/hooks/agent-end.ts
+++ b/src/hooks/agent-end.ts
@@ -10,6 +10,12 @@ import { buildAutoSessionExternalId, DECISION_KEYWORDS } from "./auto-session-st
  * Extract potential decisions from conversation messages using keyword heuristics.
  * Returns an array of { title, rationale } for each detected decision.
  */
+/** Minimum time between auto-captures per session key (ms) — prevents redundant captures in rapid exchanges */
+const CAPTURE_COOLDOWN_MS = 60_000;
+
+/** Per session-key timestamp of last capture */
+const lastCaptureAt = new Map<string, number>();
+
 export function extractDecisions(
   messages: ConversationMessage[],
 ): Array<{ title: string; rationale: string }> {
@@ -155,6 +161,18 @@ export function registerAgentEnd(
 
     // --- Capture pipeline (only when autoCapture is enabled) ---
     if (!config.autoCapture?.enabled) return;
+
+    // Per-session cooldown: skip capture if we captured recently for this session
+    const captureSessionKey = event.ctx?.sessionKey || event.sessionId || "default";
+    const captureNow = Date.now();
+    const lastCapture = lastCaptureAt.get(captureSessionKey) ?? 0;
+    if (captureNow - lastCapture < CAPTURE_COOLDOWN_MS) {
+      api.logger.debug?.(
+        `memory-memoryrelay: skipping capture (cooldown active, ${Math.round((CAPTURE_COOLDOWN_MS - (captureNow - lastCapture)) / 1000)}s remaining)`,
+      );
+      return;
+    }
+    lastCaptureAt.set(captureSessionKey, captureNow);
 
     try {
       const requestCtx = buildRequestContext(event, config);

--- a/src/hooks/before-agent-start.ts
+++ b/src/hooks/before-agent-start.ts
@@ -19,6 +19,42 @@ function resolveProjectSlug(config: PluginConfig, defaultProject: string | undef
   }
 }
 
+/** How often to check API quota — at most once every 5 minutes */
+const QUOTA_CHECK_INTERVAL_MS = 5 * 60_000;
+let lastQuotaCheckAt = 0;
+
+async function checkQuotaIfNeeded(
+  api: OpenClawPluginApi,
+  config: PluginConfig,
+  client: MemoryRelayClient,
+): Promise<void> {
+  const now = Date.now();
+  if (now - lastQuotaCheckAt < QUOTA_CHECK_INTERVAL_MS) return;
+  lastQuotaCheckAt = now;
+
+  try {
+    const health = await client.health();
+    const quota = (health as any)?.quota;
+    if (!quota?.used || !quota?.limit) return;
+
+    const pct = Math.round((quota.used / quota.limit) * 100);
+    const warnAt = config.warnAtPercent ?? 80;
+
+    if (pct >= 90 && config.autoCapture?.enabled) {
+      (config.autoCapture as any).enabled = false;
+      api.logger.warn?.(
+        `memory-memoryrelay: ⚠️  API quota at ${pct}% — auto-capture disabled to prevent quota exhaustion`,
+      );
+    } else if (pct >= warnAt) {
+      api.logger.warn?.(
+        `memory-memoryrelay: ⚠️  API quota at ${pct}% — consider reducing autoCapture or recallLimit`,
+      );
+    }
+  } catch {
+    // Non-blocking
+  }
+}
+
 export function registerBeforeAgentStart(
   api: OpenClawPluginApi,
   config: PluginConfig,
@@ -42,6 +78,9 @@ export function registerBeforeAgentStart(
         return;
       }
     }
+
+    // --- Quota check (non-blocking, max once per 5 min) ---
+    void checkQuotaIfNeeded(api, config, client);
 
     // --- Auto session lifecycle: session_start + project_context ---
     const projectSlug = resolveProjectSlug(config, defaultProject);

--- a/src/hooks/before-prompt-build.ts
+++ b/src/hooks/before-prompt-build.ts
@@ -5,6 +5,15 @@ import { buildRequestContext } from "../context/request-context.js";
 import { runPipeline } from "../pipelines/runner.js";
 import { recallPipeline } from "../pipelines/recall/index.js";
 
+/** Minimum prompt length to trigger recall — avoids burning API quota on "ok", "yes", "thanks" */
+const MIN_RECALL_PROMPT_LENGTH = 20;
+
+/** Minimum time between recall calls per session key (ms) — prevents redundant API calls in rapid exchanges */
+const RECALL_COOLDOWN_MS = 30_000;
+
+/** Per session-key timestamp of last recall */
+const lastRecallAt = new Map<string, number>();
+
 export function registerBeforePromptBuild(
   api: OpenClawPluginApi,
   config: PluginConfig,
@@ -17,7 +26,8 @@ export function registerBeforePromptBuild(
   api.on("before_prompt_build", async (event) => {
     if (!config.autoRecall) return;
 
-    if (!event.prompt || event.prompt.length < 10) return;
+    // Skip very short prompts (greetings, single-word replies, etc.)
+    if (!event.prompt || event.prompt.length < MIN_RECALL_PROMPT_LENGTH) return;
 
     // Check if current channel is excluded
     if (config.excludeChannels && event.channel) {
@@ -29,6 +39,18 @@ export function registerBeforePromptBuild(
         return;
       }
     }
+
+    // Per-session cooldown: skip recall if we just ran one recently
+    const sessionKey = event.ctx?.sessionKey || event.sessionId || "default";
+    const now = Date.now();
+    const lastRecall = lastRecallAt.get(sessionKey) ?? 0;
+    if (now - lastRecall < RECALL_COOLDOWN_MS) {
+      api.logger.debug?.(
+        `memory-memoryrelay: skipping recall (cooldown active, ${Math.round((RECALL_COOLDOWN_MS - (now - lastRecall)) / 1000)}s remaining)`,
+      );
+      return;
+    }
+    lastRecallAt.set(sessionKey, now);
 
     try {
       const requestCtx = buildRequestContext(event, config);


### PR DESCRIPTION
Implements all 5 fixes from the implementation plan in #100.

## Changes

### ⚠️ Breaking: autoCapture default is now `off`
Previously `conservative` — now requires explicit opt-in:
```json
{ "autoCapture": true }
// or fine-grained:
{ "autoCapture": { "tier": "conservative" } }
```

### Recall cooldown (`src/hooks/before-prompt-build.ts`)
- Skip recall for prompts < 20 characters (greetings, one-word replies)
- 30-second per-session cooldown between recall calls
- Reduces recall API calls by ~40-60% in active conversations

### Capture cooldown (`src/hooks/agent-end.ts`)
- 60-second per-session cooldown between auto-captures
- Prevents multiple captures in rapid back-and-forth exchanges
- Only applies when autoCapture is enabled

### Conservative recall defaults (`index.ts`)
- `recallLimit`: 5 → 3
- `recallThreshold`: 0.3 → 0.5
- Also fixed hardcoded fallbacks in tool handler code paths

### Quota warning system (`src/hooks/before-agent-start.ts`)
Checks API quota at most once per 5 minutes:
- **≥ 80%**: logs warning suggesting config adjustments
- **≥ 90%**: auto-disables autoCapture to prevent exhaustion + logs warning

The threshold is configurable via `warnAtPercent` (default: 80).

## Expected impact
For a typical active agent session with autoCapture enabled:
- ~60% fewer capture calls (cooldown)
- ~40% fewer recall calls (cooldown + length gate + threshold change)
- Early warning before quota exhaustion