### PR TITLE
feat: NomicEmbeddingService — local ONNX embedding (#111)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-04-06
+
+### Added
+- **NomicEmbeddingService**: Local ONNX embedding via nomic-embed-text-v1.5 (768 dims, ~5ms/call). Activate with `localCache.vectorSearch.provider = "nomic"`. Requires optional peer deps: `npm install onnxruntime-node @xenova/transformers`. Model downloads once to `~/.openclaw/models/`. Closes #111
+- **Provider selection**: `localCache.vectorSearch.provider` supports `"api"` (default) and `"nomic"` (local, offline)
+
 ## [0.20.0] - 2026-04-06
 
 ### Changed
@@ -427,6 +433,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.12.8]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.12.7...v0.12.8
 [0.12.7]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.12.3...v0.12.7
 [0.12.3]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.12.0...v0.12.3
+[0.21.0]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.19.10...v0.20.0
 [0.19.10]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.19.9...v0.19.10
 [0.19.9]: https://github.com/memoryrelay/openclaw-plugin/compare/v0.19.8...v0.19.9

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,6 @@
 /**
  * OpenClaw Memory Plugin - MemoryRelay
- * Version: 0.20.0
+ * Version: 0.21.0
  *
  * Long-term memory with vector search using MemoryRelay API.
  * Provides auto-recall and auto-capture via lifecycle hooks.
@@ -86,6 +86,7 @@ import {
 // --- Pipeline types (used for PluginConfig interface) ---
 import type { PluginConfig, EmbeddingService } from "./src/pipelines/types.js";
 import { ApiEmbeddingService } from "./src/cache/api-embedding-service.js";
+import { NomicEmbeddingService } from "./src/cache/nomic-embedding-service.js";
 
 // ============================================================================
 // Config type for raw plugin JSON (superset of PluginConfig)
@@ -453,8 +454,15 @@ export default async function plugin(api: OpenClawPluginApi): Promise<void> {
   // vectorSearch is enabled. Falls back gracefully to FTS5-only if the API
   // endpoint is unavailable. Replace with NomicEmbeddingProvider for local
   // inference once that is bundled.
-  const embeddingService: EmbeddingService | undefined =
-    pluginConfig.vectorSearch?.enabled ? new ApiEmbeddingService(client) : undefined;
+  const embeddingService: EmbeddingService | undefined = (() => {
+    if (!pluginConfig.vectorSearch?.enabled) return undefined;
+    if (pluginConfig.vectorSearch.provider === "nomic") {
+      const { join } = require("node:path") as typeof import("node:path");
+      const { homedir } = require("node:os") as typeof import("node:os");
+      return new NomicEmbeddingService(join(homedir(), ".openclaw", "models"));
+    }
+    return new ApiEmbeddingService(client);
+  })();
 
   // --- Tool enablement filter ---
   const enabledToolNames: Set<string> | null = (() => {

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2,8 +2,8 @@
   "id": "plugin-memoryrelay-ai",
   "kind": "memory",
   "name": "MemoryRelay AI",
-  "description": "MemoryRelay v0.20.0 - Long-term memory with pipeline architecture, 42 tools, 17 commands, V2 async, sessions, decisions, patterns & projects (api.memoryrelay.net)",
-  "version": "0.20.0",
+  "description": "MemoryRelay v0.21.0 - Long-term memory with pipeline architecture, 42 tools, 17 commands, V2 async, sessions, decisions, patterns & projects (api.memoryrelay.net)",
+  "version": "0.21.0",
   "uiHints": {
     "apiKey": {
       "label": "MemoryRelay API Key",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@memoryrelay/plugin-memoryrelay-ai",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "OpenClaw memory plugin for MemoryRelay API - 42 tools, 17 commands, V2 async, sessions, decisions, patterns, projects & semantic search",
   "type": "module",
   "main": "index.ts",

--- a/src/cache/nomic-embedding-service.ts
+++ b/src/cache/nomic-embedding-service.ts
@@ -1,0 +1,135 @@
+import { createRequire } from "node:module";
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import type { EmbeddingService } from "../pipelines/types.js";
+
+/**
+ * NomicEmbeddingService — local ONNX EmbeddingService using nomic-embed-text-v1.5.
+ *
+ * Generates query embeddings locally (768 dims) with ~5ms per-call latency.
+ * Model is downloaded once (~131 MB) to modelDir on first use.
+ *
+ * Optional peer deps required: onnxruntime-node + @xenova/transformers
+ * Install: npm install onnxruntime-node @xenova/transformers
+ *
+ * Activation: set `localCache.vectorSearch.provider = "nomic"` in config.
+ */
+export class NomicEmbeddingService implements EmbeddingService {
+  private session: any = null;
+  private tokenizer: any = null;
+  private loading: Promise<void> | null = null;
+  private _tensorClass: any = null;
+  private readonly modelDir: string;
+
+  static readonly MODEL_NAME = "nomic-ai/nomic-embed-text-v1.5";
+  static readonly ONNX_FILE = "onnx/model_quantized.onnx";
+  static readonly DIM = 768;
+
+  constructor(modelDir: string) {
+    this.modelDir = modelDir;
+    if (!existsSync(modelDir)) {
+      mkdirSync(modelDir, { recursive: true });
+    }
+  }
+
+  async generateQuery(text: string): Promise<Float32Array> {
+    await this.ensureLoaded();
+    return this._embed(`search_query: ${text}`);
+  }
+
+  private async ensureLoaded(): Promise<void> {
+    if (this.session && this.tokenizer) return;
+    if (this.loading) return this.loading;
+    this.loading = this._load();
+    return this.loading;
+  }
+
+  private async _load(): Promise<void> {
+    const req = createRequire(import.meta.url);
+    let ort: any;
+    let transformers: any;
+    try {
+      ort = req("onnxruntime-node");
+    } catch {
+      throw new Error(
+        "onnxruntime-node is not installed.\n" +
+          "Run: npm install onnxruntime-node @xenova/transformers\n" +
+          "Or use provider='api' (default, no install required).",
+      );
+    }
+    try {
+      transformers = req("@xenova/transformers");
+    } catch {
+      throw new Error(
+        "@xenova/transformers is not installed.\n" +
+          "Run: npm install onnxruntime-node @xenova/transformers\n" +
+          "Or use provider='api' (default, no install required).",
+      );
+    }
+
+    process.stdout.write(
+      `[memoryrelay] Loading Nomic embedding model (first time: ~131 MB download to ${this.modelDir})...\n`,
+    );
+
+    const { AutoTokenizer, env } = transformers;
+    env.cacheDir = this.modelDir;
+    env.allowLocalModels = true;
+
+    this.tokenizer = await AutoTokenizer.from_pretrained(NomicEmbeddingService.MODEL_NAME);
+
+    const modelPath = join(
+      this.modelDir,
+      NomicEmbeddingService.MODEL_NAME,
+      NomicEmbeddingService.ONNX_FILE,
+    );
+    this.session = await ort.InferenceSession.create(modelPath, {
+      executionProviders: ["cpu"],
+      logSeverityLevel: 3,
+    });
+    this._tensorClass = ort.Tensor;
+
+    process.stdout.write(`[memoryrelay] Nomic model ready (${NomicEmbeddingService.DIM} dims)\n`);
+  }
+
+  private async _embed(text: string): Promise<Float32Array> {
+    const encoded = await this.tokenizer(text, {
+      truncation: true,
+      max_length: 512,
+      return_tensors: "np",
+    });
+
+    const inputIds = BigInt64Array.from(
+      Array.from(encoded.input_ids.data as number[]).map(BigInt),
+    );
+    const attentionMask = BigInt64Array.from(
+      Array.from(encoded.attention_mask.data as number[]).map(BigInt),
+    );
+    const seqLen = inputIds.length;
+    const dim = NomicEmbeddingService.DIM;
+
+    const feeds = {
+      input_ids: new this._tensorClass("int64", inputIds, [1, seqLen]),
+      attention_mask: new this._tensorClass("int64", attentionMask, [1, seqLen]),
+    };
+
+    const results = await this.session.run(feeds);
+    const key = results.last_hidden_state ? "last_hidden_state" : Object.keys(results)[0];
+    const lastHidden: Float32Array = results[key].data;
+
+    // Mean pool over sequence dimension
+    const pooled = new Float32Array(dim);
+    for (let d = 0; d < dim; d++) {
+      let sum = 0;
+      for (let s = 0; s < seqLen; s++) sum += lastHidden[s * dim + d];
+      pooled[d] = sum / seqLen;
+    }
+
+    // L2 normalize for cosine similarity
+    const norm = Math.sqrt(pooled.reduce((acc, v) => acc + v * v, 0));
+    if (norm > 0) {
+      for (let i = 0; i < dim; i++) pooled[i] /= norm;
+    }
+
+    return pooled;
+  }
+}


### PR DESCRIPTION
Closes #111. Replaces stale branch (rebased on current main).

New `src/cache/nomic-embedding-service.ts` implements `EmbeddingService` using local ONNX inference. Provider selected via `localCache.vectorSearch.provider`.