### PR TITLE
docs: add TweetClaw public signal workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,16 @@ Auto-recall and smart auto-capture are enabled by default. The plugin injects re
 - Pattern adoption ensures consistent code style across sessions
 - Session tracking provides continuity when context windows reset
 
+**Public X/Twitter Signals**:
+- Install [TweetClaw](https://github.com/Xquik-dev/tweetclaw) beside MemoryRelay when an OpenClaw agent needs to search tweets, search tweet replies, export followers, run user lookup, monitor tweets, inspect media, or draft approval-gated posts and replies
+- Store reviewed findings with `memory_store`, `decision_record`, or `project_add_relationship` so MemoryRelay keeps the durable signal, not the whole timeline
+- Include query text, tweet URLs, authors, capture date, summary, confidence, and follow-up action in the memory or decision
+- Do not store X/Twitter credentials, direct message bodies, private account material, raw webhook payloads, or unreviewed post text in long-term memory
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+```
+
 ## Features -- 42 Tools by Category
 
 ### Memory (9 tools) -- group: `memory`


### PR DESCRIPTION
## Summary

- Add a README use case for installing TweetClaw beside MemoryRelay when an OpenClaw agent needs public X/Twitter signals.
- Show the canonical `openclaw plugins install @xquik/tweetclaw` command.
- Clarify that agents should store reviewed summaries, decisions, or relationships rather than credentials, direct message bodies, private account material, raw webhook payloads, or unreviewed post text.

## Validation

- git diff --check
- README Markdown link sweep
- npm view @xquik/tweetclaw@1.6.31 version dist.shasum dist.integrity --json
- npm ci --ignore-scripts --no-audit --no-fund
- npm rebuild better-sqlite3
- npm test
- npm pack --dry-run --json

Notes: `npm test` fails immediately after `npm ci --ignore-scripts` because the native `better-sqlite3` binding is not built. Running the repo-documented rebuild step fixes that, and the full suite then passes with 557 tests. The broader link sweep found the existing bare `https://memoryrelay.ai` homepage has an expired certificate from this environment; I left that unrelated site-owned issue unchanged.